### PR TITLE
updated study pages to use a static json (same for all page) of study component information

### DIFF
--- a/src/data/field-names-mapping.json
+++ b/src/data/field-names-mapping.json
@@ -12,7 +12,7 @@
     "image_acquisition": {
         "protocol_description": "Protocol description",
         "imaging_instrument_description": "Imaging Instrument",
-        "imaging_method_name": "Imaging Technique"
+        "imaging_method_name": "Imaging Method"
     },
     "analysis_method": {
         "protocol_description": "Protocol description"

--- a/src/data/field-names-mapping.json
+++ b/src/data/field-names-mapping.json
@@ -1,0 +1,20 @@
+{
+    "biosample": {
+        "organism_classification": "Organism(s) taxonomic information",
+        "biological_entity_description": "Description of biological entity"
+    },
+    "specimen_imaging_preparation_protocol": {
+        "protocol_description": "Protocol description"
+    },
+    "specimen_growth_protocol": {
+        "protocol_description": "Protocol description"
+    },
+    "image_acquisition": {
+        "protocol_description": "Protocol description",
+        "imaging_instrument_description": "Imaging Instrument",
+        "imaging_method_name": "Imaging Technique"
+    },
+    "analysis_method": {
+        "protocol_description": "Protocol description"
+    }
+}

--- a/src/data/output_modified.json
+++ b/src/data/output_modified.json
@@ -1,0 +1,163 @@
+{
+    "uuid": "UUID-study-1",
+    "title": "The sea spider Pycnogonum litorale overturns the paradigm of the absence of axial regeneration in molting animals",
+    "description": "µCT datasets of Pycnogonum litorale specimens that had been subjected to various degrees of posterior amputation.",
+    "release_date": "2023-01-31",
+    "accession_id": "S-BIAD606",
+    "licence": "CC BY 4.0",
+    "author": [
+        {
+            "display_name": "Georg Brenneis",
+            "contact_email": "georg.brenneis@univie.ac.at",
+            "affiliation": [
+                {
+                    "display_name": "University of Vienna"
+                }
+            ]
+        }
+    ],
+    "attribute": {},
+    "related_publication": [],
+    "keyword": [
+        "Pycnogonida",
+        "sea spider",
+        "Pantopoda",
+        "Arthropoda",
+        "regeneration",
+        "evolution",
+        "µCT",
+        "development",
+        "segmentation"
+    ],
+    "funding_statement": "Deutsche Forschungsgemeinschaft grant BR5039/3-1\nAssemble Plus grant as part of the European Union’s Horizon 2020 research and innovation programme under grant agreement no. 730984",
+    "experimental_imaging_component": [
+        {
+            "uuid": "UUID-experimental-imaging-dataset-1",
+            "title_id": "µCT data of Pycnogonum litorale",
+            "description": "Raw image stacks (3D tiff file format) of Pycnogonum litorale complete specimens and ROIs",
+            "image": [
+                "UUID-experimentally-captured-image-1"
+            ],
+            "file": [
+                "UUID-file-reference-1"
+            ],
+            "submitted_in_study": "UUID-study-1",
+            "specimen_imaging_preparation_protocol": [
+                {
+                    "uuid": "UUID-specimen-preparation-protocol-1",
+                    "title_id": "Pycnogonum litorale amputees",
+                    "protocol_description": "All specimens were fixed and stored in Bouin’s fluid (10% formaldehyde, 5% glacial acetic acid in saturated aqueous picric acid) at room temperature (RT). Specimens were briefly rinsed in phosphate-buffered saline (PBS; 1.86 mM NaH2PO4, 8.41 mM Na2HPO4, 175 mM NaCl, pH 7.4; at least 3× 5 min), transferred into deionized water, dehydrated via an ascending ethanol series, incubated in a tissue contrasting solution of 2% iodine (resublimated; Carl Roth; #X864.1) in 99.5% ethanol for 48 h at RT, rinsed in 99.5% ethanol (3 to 4× 10 min), and critical point-dried with a Leica EM CPD300.",
+                    "signal_channel_information": []
+                }
+            ],
+            "acquisition_process": [
+                {
+                    "uuid": "UUID-image-acquisition-1",
+                    "title_id": "Pycnogonum litorale µCT",
+                    "protocol_description": "Dried specimens were placed in plastic tubes for overview scans. For higher resolution scans of the posterior body region with the regenerates, they were subsequently attached to plastic welding rods with hot glue. Scans were performed under 40 kV/200 μA/8 W or 30 kV/200 μA/6 W settings. Depending on the specimen size and region of interest, a 4×, 10×, or 20× objective was chosen. Exposure times were individually adjusted for each scan, ranging from 0.75 to 6.5 s. To reduce noise, binning 2 was applied during data acquisition. Tomography projections were reconstructed with the XMReconstructor software (Carl Zeiss Microscopy) with binning 1 (= full resolution) and TIFF format image stacks as output.",
+                    "imaging_instrument_description": "Xradia MicroXCT-200 (Carl Zeiss Microscopy)",
+                    "imaging_method_name": "X-ray computed tomography",
+                    "fbbi_id": [
+                        "http://purl.obolibrary.org/obo/FBbi_00001002"
+                    ]
+                },
+                {
+                    "uuid": "UUID-image-acquisition-2",
+                    "title_id": "Pycnogonum litorale 1",
+                    "imaging_instrument_description": "Xradia MicroXCT-200 (Carl Zeiss Microscopy)",
+                    "imaging_method_name": "X-ray computed tomography",
+                    "fbbi_id": [
+                        "http://purl.obolibrary.org/obo/FBbi_00001002"
+                    ]
+                }
+            ],
+            "biological_entity": [
+                {
+                    "uuid": "UUID-biosample-1",
+                    "title_id": "Pycnogonida (sea spiders)",
+                    "organism_classification": [
+                        {
+                            "scientific_name": "Pycnogonum litorale",
+                            "ncbi_id": "261975"
+                        },
+                        {
+                            "common_name": "star fish",
+                            "scientific_name": null,
+                            "ncbi_id": "261975"
+                        }
+                    ],
+                    "biological_entity_description": "Complete specimens and selected ROIs"
+                },
+                {
+                    "uuid": "UUID-biosample-1",
+                    "title_id": "Pycnogonida (sea spiders) - 2",
+                    "organism_classification": [
+                        {
+                            "scientific_name": "Pycnogonum litorale",
+                            "ncbi_id": "261975"
+                        }
+                    ],
+                    "biological_entity_description": null
+                }
+            ],
+            "specimen_growth_protocol": [],
+            "analysis_method": [],
+            "correlation_method": [],
+            "file_reference_count": 1,
+            "image_count": 1,
+            "example_image_uri": []
+        },
+        {
+            "uuid": "UUID-experimental-imaging-dataset-2",
+            "title_id": "µCT data of Cambropycnogon klausmuelleri",
+            "description": "Raw image stacks (3D tiff file format) of Cambropycnogon klausmuelleri complete specimens and ROIs",
+            "image": [
+                "UUID-experimentally-captured-image-1"
+            ],
+            "file": [
+                "UUID-file-reference-1"
+            ],
+            "submitted_in_study": "UUID-study-1",
+            "specimen_imaging_preparation_protocol": [
+                {
+                    "uuid": "UUID-specimen-preparation-protocol-1",
+                    "title_id": "Pycnogonum litorale amputees",
+                    "protocol_description": "All specimens were fixed and stored in Bouin’s fluid (10% formaldehyde, 5% glacial acetic acid in saturated aqueous picric acid) at room temperature (RT). Specimens were briefly rinsed in phosphate-buffered saline (PBS; 1.86 mM NaH2PO4, 8.41 mM Na2HPO4, 175 mM NaCl, pH 7.4; at least 3× 5 min), transferred into deionized water, dehydrated via an ascending ethanol series, incubated in a tissue contrasting solution of 2% iodine (resublimated; Carl Roth; #X864.1) in 99.5% ethanol for 48 h at RT, rinsed in 99.5% ethanol (3 to 4× 10 min), and critical point-dried with a Leica EM CPD300.",
+                    "signal_channel_information": []
+                }
+            ],
+            "acquisition_process": [
+                {
+                    "uuid": "UUID-image-acquisition-1",
+                    "title_id": "Pycnogonum litorale µCT",
+                    "protocol_description": "Dried specimens were placed in plastic tubes for overview scans. For higher resolution scans of the posterior body region with the regenerates, they were subsequently attached to plastic welding rods with hot glue. Scans were performed under 40 kV/200 μA/8 W or 30 kV/200 μA/6 W settings. Depending on the specimen size and region of interest, a 4×, 10×, or 20× objective was chosen. Exposure times were individually adjusted for each scan, ranging from 0.75 to 6.5 s. To reduce noise, binning 2 was applied during data acquisition. Tomography projections were reconstructed with the XMReconstructor software (Carl Zeiss Microscopy) with binning 1 (= full resolution) and TIFF format image stacks as output.",
+                    "imaging_instrument_description": "Xradia MicroXCT-200 (Carl Zeiss Microscopy)",
+                    "imaging_method_name": "X-ray computed tomography",
+                    "fbbi_id": [
+                        "http://purl.obolibrary.org/obo/FBbi_00001002"
+                    ]
+                }
+            ],
+            "biological_entity": [
+                {
+                    "uuid": "UUID-biosample-2",
+                    "title_id": "Cambropycnogon klausmuelleri (sea spiders)",
+                    "organism_classification": [
+                        {
+                            "scientific_name": "Cambropycnogon klausmuelleri",
+                            "ncbi_id": "261975"
+                        }
+                    ],
+                    "biological_entity_description": "Complete specimens and selected ROIs"
+                }
+            ],
+            "specimen_growth_protocol": [],
+            "analysis_method": [],
+            "correlation_method": [],
+            "file_reference_count": 1,
+            "image_count": 1,
+            "example_image_uri": []
+        }
+    ],
+    "annotation_component": []
+}

--- a/src/layouts/DatasetDetailLayout.astro
+++ b/src/layouts/DatasetDetailLayout.astro
@@ -3,6 +3,7 @@
 
 const { data, field_map } = Astro.props;
 function taxon_render(taxon) {
+    //TODO: deal with partial information better, as well as link out to NCBI taxon
     return `<div>${taxon["common_name"]} (${taxon["scientific_name"]})</div>`;
 }
 

--- a/src/layouts/DatasetDetailLayout.astro
+++ b/src/layouts/DatasetDetailLayout.astro
@@ -1,0 +1,37 @@
+---
+//import field_map from "../data/field-names-mapping.json";
+
+const { data, field_map } = Astro.props;
+function taxon_render(taxon) {
+    return `<div>${taxon["common_name"]} (${taxon["scientific_name"]})</div>`;
+}
+
+function render_value(key, value) {
+    if (key === "organism_classification") {
+        return `<ul>
+            ${value.map((taxon) => taxon_render(taxon)).join("")} 
+            </ul>`;
+    } else {
+        return value;
+    }
+}
+
+const render_field = Object.keys(data).map((key) => {
+    if (key in field_map && !(data[key] == null)) {
+        return `<div><b>${field_map[key]}:</b>&nbsp; ${render_value(key, data[key])}</div>`;
+    }
+});
+
+//TODO: set this on a per-section basis
+const is_open = "True"
+---
+
+<details open={is_open}>
+    <summary>
+        <b>{data.title_id}</b>
+    </summary>
+
+    <ul>
+        <Fragment set:html={render_field} ` />
+    </ul>
+</details>

--- a/src/layouts/DatasetInfoLayout.astro
+++ b/src/layouts/DatasetInfoLayout.astro
@@ -1,0 +1,88 @@
+---
+import field_map from "../data/field-names-mapping.json";
+import DatasetDetailLayout from "./DatasetDetailLayout.astro";
+
+const { eic } = Astro.props;
+const biosample_map = field_map["biosample"];
+const sipp_map = field_map["specimen_imaging_preparation_protocol"];
+const image_acquisition_map = field_map["image_acquisition"];
+const analysis_method_map = field_map["analysis_method"];
+---
+
+<div>
+    <div>
+        <b>{eic.title_id}</b>
+    </div>
+    <ul>
+        <div>
+            <b>Description:</b>&nbsp;{eic.description}
+        </div>
+        {
+            "specimen_imaging_preparation_protocol" in eic &&
+                eic.specimen_imaging_preparation_protocol.length > 0 && (
+                    <>
+                        <b>Biosamples:</b>
+                        <ul>
+                            {eic.biological_entity.map((biosample) => (
+                                <DatasetDetailLayout
+                                    data={biosample}
+                                    field_map={biosample_map}
+                                />
+                            ))}
+                        </ul>
+                    </>
+                )
+        }
+        {
+            "specimen_imaging_preparation_protocol" in eic &&
+                eic.specimen_imaging_preparation_protocol.length > 0 && (
+                    <>
+                        <b>Specimen Preparation Protocols:</b>
+                        <ul>
+                            {eic.specimen_imaging_preparation_protocol.map(
+                                (sipp) => (
+                                    <DatasetDetailLayout
+                                        data={sipp}
+                                        field_map={sipp_map}
+                                    />
+                                ),
+                            )}
+                        </ul>
+                    </>
+                )
+        }
+        {
+            "acquisition_process" in eic &&
+                eic.acquisition_process.length > 0 && (
+                    <>
+                        <b>Image Acquisition Processes:</b>
+                        <ul>
+                            {eic.acquisition_process.map(
+                                (image_acquisition) => (
+                                    <DatasetDetailLayout
+                                        data={image_acquisition}
+                                        field_map={image_acquisition_map}
+                                    />
+                                ),
+                            )}
+                        </ul>
+                    </>
+                )
+        }
+        {
+            "analysis_method" in eic && eic.analysis_method.length > 0 && (
+                <>
+                    <b>Image Analysis Methods:</b>
+                    <ul>
+                        {eic.acquisition_process.map((analysis_method) => (
+                            <DatasetDetailLayout
+                                data={analysis_method}
+                                field_map={analysis_method_map}
+                            />
+                        ))}
+                    </ul>
+                </>
+            )
+        }
+    </ul>
+</div>

--- a/src/layouts/DatasetInfoLayout.astro
+++ b/src/layouts/DatasetInfoLayout.astro
@@ -5,6 +5,7 @@ import DatasetDetailLayout from "./DatasetDetailLayout.astro";
 const { eic } = Astro.props;
 const biosample_map = field_map["biosample"];
 const sipp_map = field_map["specimen_imaging_preparation_protocol"];
+const sgp_map = field_map["specimen_growth_protocol"];
 const image_acquisition_map = field_map["image_acquisition"];
 const analysis_method_map = field_map["analysis_method"];
 ---
@@ -18,8 +19,8 @@ const analysis_method_map = field_map["analysis_method"];
             <b>Description:</b>&nbsp;{eic.description}
         </div>
         {
-            "specimen_imaging_preparation_protocol" in eic &&
-                eic.specimen_imaging_preparation_protocol.length > 0 && (
+            "biological_entity" in eic &&
+                eic.biological_entity.length > 0 && (
                     <>
                         <b>Biosamples:</b>
                         <ul>
@@ -44,6 +45,24 @@ const analysis_method_map = field_map["analysis_method"];
                                     <DatasetDetailLayout
                                         data={sipp}
                                         field_map={sipp_map}
+                                    />
+                                ),
+                            )}
+                        </ul>
+                    </>
+                )
+        }
+        {
+            "specimen_growth_protocol" in eic &&
+                eic.specimen_growth_protocol.length > 0 && (
+                    <>
+                        <b>Specimen Growth Protocols:</b>
+                        <ul>
+                            {eic.specimen_growth_protocol.map(
+                                (sgp) => (
+                                    <DatasetDetailLayout
+                                        data={sgp}
+                                        field_map={sgp_map}
                                     />
                                 ),
                             )}

--- a/src/pages/dataset/[accession_id].astro
+++ b/src/pages/dataset/[accession_id].astro
@@ -1,11 +1,13 @@
 ---
-import BaseLayout from '../../layouts/BaseLayout.astro';
+import BaseLayout from "../../layouts/BaseLayout.astro";
 import exports from "../../data/bia-export.json";
+import DatasetInfo from "../../layouts/DatasetInfoLayout.astro";
+import StudyInfoNewDataModel from "../../data/output_modified.json";
 
 export function getStaticPaths() {
   return Object.values(exports["datasets"]).map((dataset) => {
     return {
-      params:  {accession_id: dataset.accession_id }
+      params: { accession_id: dataset.accession_id },
     };
   });
 }
@@ -15,74 +17,95 @@ const study = exports["datasets"][accession_id];
 
 const images = study.image_uuids.map((uuid) => exports["images"][uuid]);
 ---
-<BaseLayout pageTitle= {study.accession_id} >
+
+<BaseLayout pageTitle={study.accession_id}>
   <body>
     <section class="vf-intro | embl-grid embl-grid--has-centered-content">
-        <div></div>
-        <div>
-            <h1 class="vf-intro__heading vf-intro__heading--has-tag">{ study.accession_id }<a href="JavaScript:Void(0);" class="vf-badge vf-badge--primary vf-badge--phases">alpha</a></h1>
-            <h2 class="vf-intro__subheading">{ study.title }</h2>
-            Released { study.release_date }<br>
-            <!-- {{ authors }} -->
-        </div>
-         <div></div>
-    </section>
-    <section  class="vf-content | embl-grid embl-grid--has-centered-content">
-        <div>
-          <h2 class="vf-section-header__heading">Content</h2>
-          <ul class="vf-list">
-            <li>{study.n_images} images</li>
-          </ul>
-        </div>
-        <div>                  
-            <figure class="vf-figure vf-figure--align vf-figure--align-centered">
-                <img class="vf-figure__image" src={ study.example_image_uri }>
-            </figure>  
-            { study.description }
-        </div>
-        <div>
-          <a href={study.links[0]["url"]}>
-            <button class="vf-button vf-button--primary vf-button--sm">Original study</button>
-          </a>
-        </div>
-    </section>
-    <section  class="vf-content | embl-grid embl-grid--has-centered-content">
+      <div></div>
       <div>
-        <h2 class="vf-section-header__heading">Biosample</h2>
+        <h1 class="vf-intro__heading vf-intro__heading--has-tag">
+          {study.accession_id}<a
+            href="JavaScript:Void(0);"
+            class="vf-badge vf-badge--primary vf-badge--phases">alpha</a
+          >
+        </h1>
+        <h2 class="vf-intro__subheading">{study.title}</h2>
+        Released {study.release_date}<br />
+        <!-- {{ authors }} -->
       </div>
-      <div>                  
-          <b>Organism: </b> Drosophila melanogaster (fruit fly)
+      <div></div>
+    </section>
+    <section class="vf-content | embl-grid embl-grid--has-centered-content">
+      <div>
+        <h2 class="vf-section-header__heading">Content</h2>
+        <ul class="vf-list">
+          <li>{study.n_images} images</li>
+        </ul>
       </div>
-  </section>
-  <section class="vf-content | embl-grid embl-grid--has-centered-content">
-    <div></div>
-    <div>
-      <table id="viewable">
-        <thead>
-          <tr>
-            <th>Preview</th>
-            <th>Filename</th>
-            <th>Download Size</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {images.map((image) =>
+      <div>
+        <figure class="vf-figure vf-figure--align vf-figure--align-centered">
+          <img class="vf-figure__image" src={study.example_image_uri} />
+        </figure>
+        {study.description}
+      </div>
+      <div>
+        <a href={study.links[0]["url"]}>
+          <button class="vf-button vf-button--primary vf-button--sm"
+            >Original study</button
+          >
+        </a>
+      </div>
+    </section>
+    <section class="vf-content | embl-grid embl-grid--has-centered-content">
+      <div>
+        <h2 class="vf-section-header__heading">Study Information</h2>
+      </div>
+      <div> <b>Description: </b> {StudyInfoNewDataModel.description}<div/>  
+      <div> <b>Licence: </b> {StudyInfoNewDataModel.licence}<div/>
+    </section>
+    <section class="vf-content | embl-grid embl-grid--has-centered-content">
+      <div>
+        <h2 class="vf-section-header__heading">Study Component Information</h2>
+      </div>
+      <div>
+      {
+        StudyInfoNewDataModel.experimental_imaging_component.map((eic_data) => (
+          <DatasetInfo eic={eic_data} />
+        ))
+      }
+      </div>
+    </section>
+    <section class="vf-content | embl-grid embl-grid--has-centered-content">
+      <div></div>
+      <div>
+        <table id="viewable">
+          <thead>
             <tr>
-              <th>
-                <img class="vf-figure__image" src={image.thumbnail_uri}>
-              </th>
-              <th>{image.name}</th>
-              <th>3.0MiB</th>
-              <th>
-                <a href={"/image/" + image.uuid}>View</a>
-                Download
-              </th>
+              <th>Preview</th>
+              <th>Filename</th>
+              <th>Download Size</th>
+              <th>Actions</th>
             </tr>
-          )}
-        </tbody>
-      </table>
-    </div>
-  </section>
+          </thead>
+          <tbody>
+            {
+              images.map((image) => (
+                <tr>
+                  <th>
+                    <img class="vf-figure__image" src={image.thumbnail_uri} />
+                  </th>
+                  <th>{image.name}</th>
+                  <th>3.0MiB</th>
+                  <th>
+                    <a href={"/image/" + image.uuid}>View</a>
+                    Download
+                  </th>
+                </tr>
+              ))
+            }
+          </tbody>
+        </table>
+      </div>
+    </section>
   </body>
 </BaseLayout>


### PR DESCRIPTION
Added the following info to all pages:

<img width="1157" alt="image" src="https://github.com/user-attachments/assets/93942cc0-95fe-4ada-a532-04ae52e18fa0">

Currently using show/hide dropdowns that are automatically open (but it should be feasible to work out which objects are duplicates and close those)

We might be able to re-use/abstract some of the logic i've written further to really generate the whole study / dataset information sections based on the field-names-mapping.json.

I decided to keep this mapping as a standalone json, rather than try to use astro config, as it seemed like most of astro config is about build things, so i thought it might be more confusing to have this config defined in there...

Also i don't quite understand the differences between various directories in the project, so went with putting files places that vaguely sounded right.