### PR TITLE
Have open/closed dataset details section

### DIFF
--- a/src/data/bia-export-test.json
+++ b/src/data/bia-export-test.json
@@ -1,0 +1,313 @@
+{
+    "uuid": "a2fdbd58-ee11-4cd9-bc6a-f3d3da7fff71",
+    "version": 1,
+    "model": {
+        "type_name": "Study",
+        "version": 1
+    },
+    "accession_id": "S-BIADTEST",
+    "licence": "CC0",
+    "author": [
+        {
+            "rorid": null,
+            "address": null,
+            "website": null,
+            "orcid": "0000-0000-0000-0000",
+            "display_name": "Test Author1",
+            "affiliation": [
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "display_name": "Test College 1"
+                }
+            ],
+            "contact_email": "test_author1@ebi.ac.uk",
+            "role": "corresponding author"
+        },
+        {
+            "rorid": null,
+            "address": null,
+            "website": null,
+            "orcid": "1111-1111-1111-1111",
+            "display_name": "Test Author2",
+            "affiliation": [
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "display_name": "Test College 2"
+                }
+            ],
+            "contact_email": "test_author2@ebi.ac.uk",
+            "role": "first author"
+        }
+    ],
+    "title": "A test submission with title greater than 25 characters",
+    "release_date": "2024-02-13",
+    "description": "A test submission to allow testing without retrieving from bia server",
+    "keyword": [
+        "Test keyword1",
+        "Test keyword2",
+        "Test keyword3"
+    ],
+    "acknowledgement": "We thank you",
+    "see_also": [],
+    "related_publication": [],
+    "grant": [
+        {
+            "id": "TESTFUNDS1",
+            "funder": [
+                {
+                    "display_name": "Test funding body1",
+                    "id": null
+                }
+            ]
+        },
+        {
+            "id": "TESTFUNDS2",
+            "funder": [
+                {
+                    "display_name": "Test funding body2",
+                    "id": null
+                }
+            ]
+        }
+    ],
+    "funding_statement": "This work was funded by the EBI",
+    "attribute": {},
+    "experimental_imaging_component": [
+        {
+            "title_id": "Study Component 1",
+            "uuid": "47a4ab60-c76d-4424-bfaa-c2a024de720c",
+            "version": 1,
+            "model": {
+                "type_name": "ExperimentalImagingDataset",
+                "version": 1
+            },
+            "description": "Description of study component 1",
+            "attribute": {
+                "associations": [
+                    {
+                        "biosample": "Test Biosample 1",
+                        "image_acquisition": "Test Primary Screen Image Acquisition",
+                        "specimen": "Test specimen 1"
+                    },
+                    {
+                        "biosample": "Test Biosample 2",
+                        "image_acquisition": "Test Primary Screen Image Acquisition",
+                        "specimen": "Test specimen 1"
+                    }
+                ]
+            },
+            "analysis_method": [
+                {
+                    "protocol_description": "Test image analysis",
+                    "features_analysed": "Test image analysis overview"
+                }
+            ],
+            "correlation_method": [],
+            "example_image_uri": [],
+            "submitted_in_study_uuid": "a2fdbd58-ee11-4cd9-bc6a-f3d3da7fff71",
+            "acquisition_process": [
+                {
+                    "title_id": "Test Primary Screen Image Acquisition",
+                    "uuid": "c2e44a1b-a43c-476e-8ddf-8587f4c955b3",
+                    "version": 1,
+                    "model": {
+                        "type_name": "ImageAcquisition",
+                        "version": 1
+                    },
+                    "protocol_description": "Test image acquisition parameters 1",
+                    "imaging_instrument_description": "Test imaging instrument 1",
+                    "fbbi_id": [],
+                    "imaging_method_name": "confocal microscopy"
+                }
+            ],
+            "specimen_imaging_preparation_protocol": [
+                {
+                    "title_id": "Test specimen 1",
+                    "uuid": "7199d730-29f1-4ad8-b599-e9089cbb2d7b",
+                    "version": 1,
+                    "model": {
+                        "type_name": "SpecimenImagingPrepartionProtocol",
+                        "version": 1
+                    },
+                    "protocol_description": "Test sample preparation protocol 1",
+                    "signal_channel_information": []
+                }
+            ],
+            "biological_entity": [
+                {
+                    "title_id": "Test Biosample 1",
+                    "uuid": "64a67727-4e7c-469a-91c4-6219ae072e99",
+                    "version": 1,
+                    "model": {
+                        "type_name": "BioSample",
+                        "version": 1
+                    },
+                    "organism_classification": [
+                        {
+                            "common_name": "human",
+                            "scientific_name": "Homo sapiens",
+                            "ncbi_id": null
+                        }
+                    ],
+                    "biological_entity_description": "Test biological entity 1",
+                    "experimental_variable_description": [
+                        "Test experimental entity 1"
+                    ],
+                    "extrinsic_variable_description": [
+                        "Test extrinsic variable 1"
+                    ],
+                    "intrinsic_variable_description": [
+                        "Test intrinsic variable 1\\nwith escaped character"
+                    ]
+                },
+                {
+                    "title_id": "Test Biosample 2",
+                    "uuid": "6950718c-4917-47a1-a807-11b874e80a23",
+                    "version": 1,
+                    "model": {
+                        "type_name": "BioSample",
+                        "version": 1
+                    },
+                    "organism_classification": [
+                        {
+                            "common_name": "mouse",
+                            "scientific_name": "Mus musculus",
+                            "ncbi_id": null
+                        }
+                    ],
+                    "biological_entity_description": "Test biological entity 2",
+                    "experimental_variable_description": [
+                        "Test experimental entity 2"
+                    ],
+                    "extrinsic_variable_description": [
+                        "Test extrinsic variable 2"
+                    ],
+                    "intrinsic_variable_description": [
+                        "Test intrinsic variable 2"
+                    ]
+                }
+            ],
+            "specimen_growth_protocol": []
+        },
+        {
+            "title_id": "Study Component 2",
+            "uuid": "47a4ab60-c76d-4424-bfaa-c2a024de720c",
+            "version": 1,
+            "model": {
+                "type_name": "ExperimentalImagingDataset",
+                "version": 1
+            },
+            "description": "Description of study component 1",
+            "attribute": {
+                "associations": [
+                    {
+                        "biosample": "Test Biosample 1",
+                        "image_acquisition": "Test Primary Screen Image Acquisition",
+                        "specimen": "Test specimen 1"
+                    },
+                    {
+                        "biosample": "Test Biosample 2",
+                        "image_acquisition": "Test Primary Screen Image Acquisition",
+                        "specimen": "Test specimen 1"
+                    }
+                ]
+            },
+            "analysis_method": [
+                {
+                    "protocol_description": "Test image analysis",
+                    "features_analysed": "Test image analysis overview"
+                }
+            ],
+            "correlation_method": [],
+            "example_image_uri": [],
+            "submitted_in_study_uuid": "a2fdbd58-ee11-4cd9-bc6a-f3d3da7fff71",
+            "acquisition_process": [
+                {
+                    "title_id": "Test Primary Screen Image Acquisition",
+                    "uuid": "c2e44a1b-a43c-476e-8ddf-8587f4c955b3",
+                    "version": 1,
+                    "model": {
+                        "type_name": "ImageAcquisition",
+                        "version": 1
+                    },
+                    "protocol_description": "Test image acquisition parameters 1",
+                    "imaging_instrument_description": "Test imaging instrument 1",
+                    "fbbi_id": [],
+                    "imaging_method_name": "confocal microscopy"
+                }
+            ],
+            "specimen_imaging_preparation_protocol": [
+                {
+                    "title_id": "Test specimen 1",
+                    "uuid": "7199d730-29f1-4ad8-b599-e9089cbb2d7b",
+                    "version": 1,
+                    "model": {
+                        "type_name": "SpecimenImagingPrepartionProtocol",
+                        "version": 1
+                    },
+                    "protocol_description": "Test sample preparation protocol 1",
+                    "signal_channel_information": []
+                }
+            ],
+            "biological_entity": [
+                {
+                    "title_id": "Test Biosample 1",
+                    "uuid": "64a67727-4e7c-469a-91c4-6219ae072e99",
+                    "version": 1,
+                    "model": {
+                        "type_name": "BioSample",
+                        "version": 1
+                    },
+                    "organism_classification": [
+                        {
+                            "common_name": "human",
+                            "scientific_name": "Homo sapiens",
+                            "ncbi_id": null
+                        }
+                    ],
+                    "biological_entity_description": "Test biological entity 1",
+                    "experimental_variable_description": [
+                        "Test experimental entity 1"
+                    ],
+                    "extrinsic_variable_description": [
+                        "Test extrinsic variable 1"
+                    ],
+                    "intrinsic_variable_description": [
+                        "Test intrinsic variable 1\\nwith escaped character"
+                    ]
+                },
+                {
+                    "title_id": "Test Biosample 3",
+                    "uuid": "6950718c-4917-47a1-a807-11b874e80a23",
+                    "version": 1,
+                    "model": {
+                        "type_name": "BioSample",
+                        "version": 1
+                    },
+                    "organism_classification": [
+                        {
+                            "common_name": "mouse",
+                            "scientific_name": "Mus musculus",
+                            "ncbi_id": null
+                        }
+                    ],
+                    "biological_entity_description": "Test biological entity 2",
+                    "experimental_variable_description": [
+                        "Test experimental entity 2"
+                    ],
+                    "extrinsic_variable_description": [
+                        "Test extrinsic variable 2"
+                    ],
+                    "intrinsic_variable_description": [
+                        "Test intrinsic variable 2"
+                    ]
+                }
+            ],
+            "specimen_growth_protocol": []
+        }
+    ]
+}

--- a/src/data/output_modified.json
+++ b/src/data/output_modified.json
@@ -44,6 +44,7 @@
             "submitted_in_study": "UUID-study-1",
             "specimen_imaging_preparation_protocol": [
                 {
+                    "default_open": true,
                     "uuid": "UUID-specimen-preparation-protocol-1",
                     "title_id": "Pycnogonum litorale amputees",
                     "protocol_description": "All specimens were fixed and stored in Bouin’s fluid (10% formaldehyde, 5% glacial acetic acid in saturated aqueous picric acid) at room temperature (RT). Specimens were briefly rinsed in phosphate-buffered saline (PBS; 1.86 mM NaH2PO4, 8.41 mM Na2HPO4, 175 mM NaCl, pH 7.4; at least 3× 5 min), transferred into deionized water, dehydrated via an ascending ethanol series, incubated in a tissue contrasting solution of 2% iodine (resublimated; Carl Roth; #X864.1) in 99.5% ethanol for 48 h at RT, rinsed in 99.5% ethanol (3 to 4× 10 min), and critical point-dried with a Leica EM CPD300.",
@@ -52,6 +53,7 @@
             ],
             "acquisition_process": [
                 {
+                    "default_open": true,
                     "uuid": "UUID-image-acquisition-1",
                     "title_id": "Pycnogonum litorale µCT",
                     "protocol_description": "Dried specimens were placed in plastic tubes for overview scans. For higher resolution scans of the posterior body region with the regenerates, they were subsequently attached to plastic welding rods with hot glue. Scans were performed under 40 kV/200 μA/8 W or 30 kV/200 μA/6 W settings. Depending on the specimen size and region of interest, a 4×, 10×, or 20× objective was chosen. Exposure times were individually adjusted for each scan, ranging from 0.75 to 6.5 s. To reduce noise, binning 2 was applied during data acquisition. Tomography projections were reconstructed with the XMReconstructor software (Carl Zeiss Microscopy) with binning 1 (= full resolution) and TIFF format image stacks as output.",
@@ -62,6 +64,7 @@
                     ]
                 },
                 {
+                    "default_open": true,
                     "uuid": "UUID-image-acquisition-2",
                     "title_id": "Pycnogonum litorale 1",
                     "imaging_instrument_description": "Xradia MicroXCT-200 (Carl Zeiss Microscopy)",
@@ -73,6 +76,7 @@
             ],
             "biological_entity": [
                 {
+                    "default_open": true,
                     "uuid": "UUID-biosample-1",
                     "title_id": "Pycnogonida (sea spiders)",
                     "organism_classification": [
@@ -89,7 +93,8 @@
                     "biological_entity_description": "Complete specimens and selected ROIs"
                 },
                 {
-                    "uuid": "UUID-biosample-1",
+                    "default_open": true,
+                    "uuid": "UUID-biosample-2",
                     "title_id": "Pycnogonida (sea spiders) - 2",
                     "organism_classification": [
                         {
@@ -120,6 +125,7 @@
             "submitted_in_study": "UUID-study-1",
             "specimen_imaging_preparation_protocol": [
                 {
+                    "default_open": false,
                     "uuid": "UUID-specimen-preparation-protocol-1",
                     "title_id": "Pycnogonum litorale amputees",
                     "protocol_description": "All specimens were fixed and stored in Bouin’s fluid (10% formaldehyde, 5% glacial acetic acid in saturated aqueous picric acid) at room temperature (RT). Specimens were briefly rinsed in phosphate-buffered saline (PBS; 1.86 mM NaH2PO4, 8.41 mM Na2HPO4, 175 mM NaCl, pH 7.4; at least 3× 5 min), transferred into deionized water, dehydrated via an ascending ethanol series, incubated in a tissue contrasting solution of 2% iodine (resublimated; Carl Roth; #X864.1) in 99.5% ethanol for 48 h at RT, rinsed in 99.5% ethanol (3 to 4× 10 min), and critical point-dried with a Leica EM CPD300.",
@@ -128,6 +134,7 @@
             ],
             "acquisition_process": [
                 {
+                    "default_open": false,
                     "uuid": "UUID-image-acquisition-1",
                     "title_id": "Pycnogonum litorale µCT",
                     "protocol_description": "Dried specimens were placed in plastic tubes for overview scans. For higher resolution scans of the posterior body region with the regenerates, they were subsequently attached to plastic welding rods with hot glue. Scans were performed under 40 kV/200 μA/8 W or 30 kV/200 μA/6 W settings. Depending on the specimen size and region of interest, a 4×, 10×, or 20× objective was chosen. Exposure times were individually adjusted for each scan, ranging from 0.75 to 6.5 s. To reduce noise, binning 2 was applied during data acquisition. Tomography projections were reconstructed with the XMReconstructor software (Carl Zeiss Microscopy) with binning 1 (= full resolution) and TIFF format image stacks as output.",
@@ -140,6 +147,7 @@
             ],
             "biological_entity": [
                 {
+                    "default_open": true,
                     "uuid": "UUID-biosample-2",
                     "title_id": "Cambropycnogon klausmuelleri (sea spiders)",
                     "organism_classification": [

--- a/src/layouts/DatasetDetailLayout.astro
+++ b/src/layouts/DatasetDetailLayout.astro
@@ -23,13 +23,12 @@ const render_field = Object.keys(data).map((key) => {
     }
 });
 
-//TODO: set this on a per-section basis
-const is_open = "True"
+
 ---
 
-<details open={is_open}>
+<details open={data.default_open}>
     <summary>
-        <b>{data.title_id}</b>
+        <b>{data.title_id}</b> {data.default_open? ' ':'(as above)'}
     </summary>
 
     <ul>


### PR DESCRIPTION
updated Dataset Detail to use default_open field to modify details open/closed and header.

May have git conflicts with: https://github.com/BioImage-Archive/BIA-astro/pull/10 (but not logic conflicts)

Uses expected json output of https://github.com/BioImage-Archive/bia-integrator/pull/140

Part of: https://app.clickup.com/t/86956nvk4