### PR TITLE
added logic to grab actual images, falling back to trec

### DIFF
--- a/src/components/BrowseDatasetCard.astro
+++ b/src/components/BrowseDatasetCard.astro
@@ -5,10 +5,18 @@ import default_img_3 from "../assets/bioimage-archive/default_hero/default_hero_
 import default_img_4 from "../assets/bioimage-archive/default_hero/default_hero_4.png"
 
 const { dataset, dataset_path } = Astro.props;
-// Note these images are just to get an idea of the display in dev whilst also being obviously not actual images from the study.
-// Will switch to actual images once we have these.
-const images = {"0": default_img_1, "1": default_img_2, "2": default_img_3, "3": default_img_4}
-const image = images[String(dataset.accession_id.slice(6)%4)] 
+
+function get_study_image(study_info) {
+  const dataset_with_img = study_info.experimental_imaging_component.find((eic) => eic.example_image_uri.length > 0)
+  if (dataset_with_img == undefined) {
+    // Note these images are just to get an idea of the display in dev whilst also being obviously not actual images from the study.
+    // Will switch to actual images once we have these.
+    const images = {"0": default_img_1, "1": default_img_2, "2": default_img_3, "3": default_img_4}
+    return images[String(dataset.accession_id.slice(6)%4)].src 
+  } else {
+    return dataset_with_img.example_image_uri[0]
+  }
+}
 
 function get_imaging_type(study_info) {
     var imaging_type_list = new Array()
@@ -78,7 +86,7 @@ function display_taxon(dataset) {
 }
 ---
 <article class="vf-card vf-card--brand vf-card--bordered">
-    <img src={ image.src } alt="" class="vf-card__image" loading="lazy" style="aspect-ratio: 1/1;">
+    <img src={ get_study_image(dataset) } alt="" class="vf-card__image" loading="lazy" style="aspect-ratio: 1/1;">
     <div class="vf-card__content | vf-stack vf-stack--400">
         <h3 class="vf-card__heading">
             <a class="vf-card__link" href={ "/bioimage-archive/"+ dataset_path + "/" + dataset.accession_id } >

--- a/src/pages/dataset/[accession_id].astro
+++ b/src/pages/dataset/[accession_id].astro
@@ -35,6 +35,15 @@ for (var dataset of study_info.experimental_imaging_component) {
   }
 }
 
+function get_study_image(study_info) {
+  const dataset_with_img = study_info.experimental_imaging_component.find((dataset) => dataset.example_image_uri.length > 0)
+  if (dataset_with_img == undefined) {
+    return default_img.src
+  } else {
+    return dataset_with_img.example_image_uri[0]
+  }
+}
+
 ---
 
 <BaseLayout pageTitle={study_info.accession_id}>
@@ -63,7 +72,7 @@ for (var dataset of study_info.experimental_imaging_component) {
 
       <div>
         <figure class="vf-figure vf-figure--align vf-figure--align-centered">
-          <img class="vf-figure__image" src={default_img.src} />
+          <img class="vf-figure__image" src={get_study_image(study_info)} />
         </figure>
       </div>
 


### PR DESCRIPTION
Note that i did not commit any changes to the data, but here are some examples of it working using an image from an old study.

Logic involves fetching the first image from any datasets. I've found a cool carousel component in astro that we might want to use in the future - otherwise we might want to consider model updates to put this data on the study, rather than datasets (but i think datasets is the better option even if the code is more complicated)

<img width="1028" alt="Screenshot 2024-09-06 at 16 21 37" src="https://github.com/user-attachments/assets/0f6efc3c-bde1-4ddb-9a40-6db57e270d97">


<img width="1348" alt="image" src="https://github.com/user-attachments/assets/b2320df1-816d-49c4-a8f5-132f021f5b28">
