### PR TITLE
Text & field fixes

### DIFF
--- a/src/pages/dataset/[accession_id].astro
+++ b/src/pages/dataset/[accession_id].astro
@@ -141,7 +141,7 @@ function get_study_image(study_info) {
         <tbody>
           {
             images.map((image) => (
-              <ImageRow image={image} study_title={study_info.experimental_imaging_component.find((dataset) => dataset.uuid === image.submission_dataset_uuid ).title_id}/>
+              <ImageRow image={image} dataset_title={study_info.experimental_imaging_component.find((dataset) => dataset.uuid == image.submission_dataset_uuid).title_id}/>
             ))
           }
         </tbody>

--- a/src/pages/dataset/[accession_id].astro
+++ b/src/pages/dataset/[accession_id].astro
@@ -132,9 +132,9 @@ function get_study_image(study_info) {
         <thead>
           <tr>
             <th>Preview</th>
-            <th>Filename</th>
+            <th>UUID</th>
             <th>Dataset</th>
-            <th>Download Size</th>
+            <th>Download Size (bytes)</th>
             <th>Actions</th>
           </tr>
         </thead>

--- a/src/pages/image/[uuid].astro
+++ b/src/pages/image/[uuid].astro
@@ -93,7 +93,7 @@ function pixel_dimensions(value, text) {
                 <b>Physical Image size: </b> {format_physical_dimensions(interactive_image)}<br>
                 <b>Pixel Image size: </b> {format_pixel_dimensions(interactive_image)}<br>
                 {interactive_image.size_c != null && (<><b>Number of channels:</b> {interactive_image.size_c}<br/></>)}
-                {interactive_image.size_t != null && (<><b>Number of timesteps:</b> {interactive_image.size_c}<br/></>)}
+                {interactive_image.size_t != null && (<><b>Number of timesteps:</b> {interactive_image.size_t}<br/></>)}
                 {Object.entries(image.attribute).map(([key, value]) => (
                     <p>{key}: {value}</p>
                 ))}


### PR DESCRIPTION
Change study-image-table headers:
- Filename changed to UUID
- Added (bytes) as unit for size

Fixed field filling for:
- Study-image-table dataset column
- Image page (number of timesteps) size_t*

*note i tested this one locally by changing the data (it's not obvious because all the test values are 1) but don't want to change the data in the git repo unnecessarily to cause conflicts with Kola's PRs