### PR TITLE
increase timeout for waiting for netlify deployment

### DIFF
--- a/.github/workflows/basic_checks.yaml
+++ b/.github/workflows/basic_checks.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: jakepartusch/wait-for-netlify-action@v1.4
         with:
           site_name: ${{ env.site_name }}
-          max_timeout: 60
+          max_timeout: 180
 
   link-check:
     needs: wait-for-deploy


### PR DESCRIPTION
Seems to take about 2 minutes to complete deployment, so increasing the timeout to 3 minutes should cover