### PR TITLE
add overflow-wrap to detail text

### DIFF
--- a/src/components/DatasetDetail.astro
+++ b/src/components/DatasetDetail.astro
@@ -32,7 +32,7 @@ function render_value(key, value) {
 
 const render_field = Object.keys(data).map((key) => {
     if (key in field_map && !(data[key] == null)) {
-        return `<div><b>${field_map[key]}:</b>&nbsp; ${render_value(key, data[key])}</div>`;
+        return `<div style="overflow-wrap: anywhere;"><b>${field_map[key]}:</b>&nbsp; ${render_value(key, data[key])}</div>`;
     }
 });
 

--- a/src/components/DatasetDetail.astro
+++ b/src/components/DatasetDetail.astro
@@ -20,13 +20,18 @@ function taxon_render(taxon) {
     }
 }
 
+export function multiline_text_render(value) {
+    const output = value.toString().trim().replace(/(?:[\r\n|\r|\n]+)/g, "<br/><br/>")
+    return output
+}
+
 function render_value(key, value) {
     if (key === "organism_classification") {
         return `<ul>
             ${value.map((taxon) => taxon_render(taxon)).join("")} 
             </ul>`;
     } else {
-        return value;
+        return multiline_text_render(value)
     }
 }
 

--- a/src/pages/dataset/[accession_id].astro
+++ b/src/pages/dataset/[accession_id].astro
@@ -7,6 +7,7 @@ import StudyTitleInfo from "../../components/StudyTitleInfo.astro";
 import DatasetInfo from "../../components/DatasetInfo.astro";
 import ImageRow from "../../components/ImageRow.astro";
 import default_img from "../../assets/bioimage-archive/default_hero/default_hero_1.png"
+import {multiline_text_render} from "../../components/DatasetDetail.astro"
 
 export function getStaticPaths() {
   return Object.values(StudyMetadata).map((dataset) => {
@@ -93,7 +94,7 @@ function get_study_image(study_info) {
       </div>
 
       <div style="overflow-wrap: anywhere;">
-        <div><b>Description: </b>{study_info.description}</div>
+        <div><b>Description: </b> <Fragment set:html={multiline_text_render(study_info.description)}></Fragment></div>
         <div><b>Licence: </b> {study_info.licence}<div>
       </div>
     </section>

--- a/src/pages/dataset/[accession_id].astro
+++ b/src/pages/dataset/[accession_id].astro
@@ -92,7 +92,7 @@ function get_study_image(study_info) {
         <h2 class="vf-section-header__heading">Study Information</h2>
       </div>
 
-      <div>
+      <div style="overflow-wrap: anywhere;">
         <div><b>Description: </b>{study_info.description}</div>
         <div><b>Licence: </b> {study_info.licence}<div>
       </div>

--- a/src/pages/image/[uuid].astro
+++ b/src/pages/image/[uuid].astro
@@ -146,7 +146,7 @@ function pixel_dimensions(value, text) {
             <div>
                 <h3>Study</h3>
             </div>
-            <div>
+            <div style="overflow-wrap: anywhere;">
                 <b>Title</b>: {image_study.title}<br/>
                 <b>Description:</b> {image_study.description} <br/>
                 <b>Licence:</b> {image_study.licence} <br/>


### PR DESCRIPTION
add overflow-wrap anywhere to details and description sections to cope with very long urls

e.g: https://deploy-preview-33--bia-beta-website.netlify.app/bioimage-archive/dataset/s-biad986/

Also added in regex to cope with some user inputted newlines that make it easier to read longer texts. E.g. (the link above) and:

study information description: https://deploy-preview-33--bia-beta-website.netlify.app/bioimage-archive/dataset/s-biad957/ 

and protocol description: https://deploy-preview-33--bia-beta-website.netlify.app/bioimage-archive/dataset/s-biad676/