### PR TITLE
filter parameters and benchmarking rows

### DIFF
--- a/src/components/ai-benchmarking/BenchmarkingTable.astro
+++ b/src/components/ai-benchmarking/BenchmarkingTable.astro
@@ -27,8 +27,10 @@ export function format_param(acc, keyvalue) {
 
 export function format_analysis_param(analysis_params) {
 
-    return Object.entries(analysis_params).reduce(format_param, "")
+    return Object.entries(analysis_params).filter(([key, value]) => value != null).reduce(format_param, "")
 }
+
+const filtered_table_rows = table_rows.filter(row => row.precision != null)
 
 ---
 
@@ -65,7 +67,7 @@ export function format_analysis_param(analysis_params) {
             </thead>
             <tbody class="vf_table__body">
             {
-                table_rows.map((row) => (
+                filtered_table_rows.map((row) => (
                 <tr>
                     {
                         study_or_model == 'model' && (

--- a/src/components/ai-benchmarking/ModelPage.astro
+++ b/src/components/ai-benchmarking/ModelPage.astro
@@ -4,7 +4,7 @@ import ModelPredictionTable from "./ModelPredictionTable.astro"
 import { format_list_item, multiline_text_render } from "../SharedJSFunctions";
 
 
-const { model_name, ModelMetadata, TableInfo} = Astro.props;
+const { model_name, ModelMetadata, TableInfo, logo_basepath} = Astro.props;
 
 
 const model_info = ModelMetadata[model_name]
@@ -45,10 +45,10 @@ const filtered_table_info = TableInfo.filter( row =>
 
          <span style="display: flex; justify-content: space-evenly; flex-wrap: wrap; padding-top:8px">
             <a href="https://ai4life.eurobioimaging.eu/" class="vf-badge vf-badge--primary" style="height: 60px; width: 240px; display: flex; justify-content: space-evenly;">
-                <img src="/bioimage-archive/ai-galleries/AI4Life_logo_neg_giraffe_solid.png" style="max-height:140%; padding-top:-40%">
+                <img src={logo_basepath + "AI4Life_logo_neg_giraffe_solid.png"} style="max-height:140%; padding-top:-40%">
             </a>
             <a href="https://bioimage.io/#/" class="vf-badge vf-badge--primary" style="height: 60px; width: 240px; display: flex; justify-content: space-evenly;">
-                <img src="/bioimage-archive/ai-galleries/bioimage-io-logo-white.png" style="max-height:80%; padding:10px">  
+                <img src={logo_basepath + "bioimage-io-logo-white.png"} style="max-height:80%; padding:10px">  
             </a>
          </span>
 

--- a/src/pages/galleries/ai/model/[model_name].astro
+++ b/src/pages/galleries/ai/model/[model_name].astro
@@ -19,5 +19,5 @@ const { model_name } = Astro.params;
 
 ---
 <BaseLayout pageTitle={model_name}>
-  <ModelPage model_name={model_name} ModelMetadata={ModelMetadata} TableInfo={TableInfo} />
+  <ModelPage model_name={model_name} ModelMetadata={ModelMetadata} TableInfo={TableInfo} logo_basepath="/bioimage-archive/ai-galleries/"/>
 </BaseLayout>


### PR DESCRIPTION
![Screenshot 2025-02-05 at 13 19 10](https://github.com/user-attachments/assets/22e3771c-85fb-4453-96d4-941f2c05e17a)

format_analysis_param is exported to the other table, so this fixes both.



\+ small improvement making the logo basepath configurable (to make it easier for old-website to update the paths)

