### PR TITLE
added about this alpha page to help pages, and banner on index

### DIFF
--- a/src/components/BrowseDatasetsHeading.astro
+++ b/src/components/BrowseDatasetsHeading.astro
@@ -1,4 +1,5 @@
 ---
+import WebsiteStateButton from "./WebsiteStateButton.astro";
 
 const { heading, subheading, contributeLink } = Astro.props;
 
@@ -8,7 +9,8 @@ const { heading, subheading, contributeLink } = Astro.props;
     <div>
         <h1 class="vf-intro__heading vf-intro__heading--has-tag">
           {heading}
-          <a href="JavaScript:Void(0);" class="vf-badge vf-badge--primary vf-badge--phases">alpha</a></h1>
+          <WebsiteStateButton/>
+        </h1>
         {
           subheading && (
             <h2 class="vf-intro__subheading">

--- a/src/components/HelpNavigation.astro
+++ b/src/components/HelpNavigation.astro
@@ -32,13 +32,16 @@ function addTrailingSlash(pathname: String) {
 const pathName = addTrailingSlash(Astro.url.pathname)
 const pageName = pathName.split('/').at(-2);
 ---
-  <ul class="vf-list vf-list--l">
-    <li class={pageName === "help" ? "vf-list__item | active" : "vf-list__item"}>
-      <a href={`/bioimage-archive/help`} class="vf-navigation__link">Help Overview</a>
+<ul class="vf-list vf-list--l">
+  <li class={pageName === "help" ? "vf-list__item | active" : "vf-list__item"}>
+    <a href={`/bioimage-archive/help`} class="vf-navigation__link">Help Overview</a>
   </li>
-  </ul>
-  <details class="vf-details" open={pageName in submissionHelp ? true : false}>
-    <summary class="vf-details--summary">Submission Help</summary>
+  <li class={pageName === "about-this-alpha" ? "vf-list__item | active" : "vf-list__item"}>
+    <a href=`/bioimage-archive/help/about-this-alpha` class="vf-navigation__link">About this Alpha</a>
+  </li>
+</ul>
+<details class="vf-details" open={pageName in submissionHelp ? true : false}>
+  <summary class="vf-details--summary">Submission Help</summary>
   <ul class="vf-list vf-list--l">
     {Object.entries(submissionHelp).map(([key, value]) => (
       <li class={pageName === key ? "vf-list__item | active" : "vf-list__item"}>

--- a/src/components/HelpNavigation.astro
+++ b/src/components/HelpNavigation.astro
@@ -36,8 +36,8 @@ const pageName = pathName.split('/').at(-2);
   <li class={pageName === "help" ? "vf-list__item | active" : "vf-list__item"}>
     <a href={`/bioimage-archive/help`} class="vf-navigation__link">Help Overview</a>
   </li>
-  <li class={pageName === "about-this-alpha" ? "vf-list__item | active" : "vf-list__item"}>
-    <a href=`/bioimage-archive/help/about-this-alpha` class="vf-navigation__link">About this Alpha</a>
+  <li class={pageName === "about-the-new-website" ? "vf-list__item | active" : "vf-list__item"}>
+    <a href=`/bioimage-archive/help/about-the-new-website` class="vf-navigation__link">About the new website</a>
   </li>
 </ul>
 <details class="vf-details" open={pageName in submissionHelp ? true : false}>

--- a/src/components/WebsiteStateButton.astro
+++ b/src/components/WebsiteStateButton.astro
@@ -1,0 +1,6 @@
+---
+---
+
+<a href="/bioimage-archive/help/about-the-new-website" class="vf-badge vf-badge--primary vf-badge--phases">
+    alpha
+</a >

--- a/src/components/ai-benchmarking/ModelPage.astro
+++ b/src/components/ai-benchmarking/ModelPage.astro
@@ -1,6 +1,8 @@
 ---
 import BenchmarkingTable from "./BenchmarkingTable.astro"
 import ModelPredictionTable from "./ModelPredictionTable.astro"
+import WebsiteStateButton from "../WebsiteStateButton.astro";
+
 import { formatListItem, multilineTextRender } from "../SharedJSFunctions";
 
 
@@ -26,10 +28,8 @@ const filteredTableInfo = tableInfo.filter( row => row.model === modelName)
     </div>
     <div>
         <h1 class="vf-intro__heading vf-intro__heading--has-tag">
-            {modelInfo.nickname}<a
-                href="JavaScript:Void(0);"
-                class="vf-badge vf-badge--primary vf-badge--phases">alpha</a
-            >
+            {modelInfo.nickname}
+            <WebsiteStateButton/>
         </h1>
         <h2 class="vf-intro__subheading">{modelInfo.name}</h2>
 

--- a/src/components/study-page/StudyTitleInfo.astro
+++ b/src/components/study-page/StudyTitleInfo.astro
@@ -1,4 +1,6 @@
 ---
+import WebsiteStateButton from "../WebsiteStateButton.astro";
+
 const { study_info: studyInfo } = Astro.props;
 
 const authors = "author" in studyInfo ? studyInfo.author : [{display_name: ""}];
@@ -22,10 +24,8 @@ function authorFormat(author_name, i, author_list) {
     </div>
     <div>
         <h1 class="vf-intro__heading vf-intro__heading--has-tag">
-            {studyInfo.accession_id}<a
-                href="JavaScript:Void(0);"
-                class="vf-badge vf-badge--primary vf-badge--phases">alpha</a
-            >
+            {studyInfo.accession_id}
+            <WebsiteStateButton/>
         </h1>
         <h2 class="vf-intro__subheading">{studyInfo.title}</h2>
         <p>Released {studyInfo.release_date}</p>

--- a/src/pages/galleries/cryoet.astro
+++ b/src/pages/galleries/cryoet.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import TomogramCard from '../../components/cards/TomogramCard.astro';
+import WebsiteStateButton from '../../components/WebsiteStateButton.astro';
 import tomoproj from "../../data/collections/tomp.json";
 const tomograms = tomoproj["tomograms"];
 ---
@@ -9,7 +10,9 @@ const tomograms = tomoproj["tomograms"];
     <section class="vf-intro | embl-grid embl-grid--has-centered-content">
         <div></div>
         <div>
-            <h1 class="vf-intro__heading vf-intro__heading--has-tag"> EMPIAR-11756 <a href="JavaScript:Void(0);" class="vf-badge vf-badge--primary vf-badge--phases">alpha</a></h1>
+            <h1 class="vf-intro__heading vf-intro__heading--has-tag"> EMPIAR-11756 
+              <WebsiteStateButton/>
+            </h1>
             <h2 class="vf-intro__subheading">Individual tomograms with visualisation links</h2>
             <!-- <p class="vf-hero__text">{ collection.description }</p> -->
             <p></p>

--- a/src/pages/galleries/image/[uuid].astro
+++ b/src/pages/galleries/image/[uuid].astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '../../../layouts/BaseLayout.astro';
 import SourceImage from "../../../components/SourceImage.astro"
+import WebsiteStateButton from '../../../components/WebsiteStateButton.astro';
 
 import exports from "../../../data/old-export-format/bia-images-export.json";
 import studyData from "../../../data/old-export-format/bia-export.json";
@@ -46,7 +47,9 @@ const base_img_s3_url = image.vizarr_uri.replace('https://uk1s3.embassy.ebi.ac.u
         <section class="vf-content | embl-grid embl-grid--has-centered-content">
             <div></div>
             <div>
-                <h1 class="vf-intro__heading vf-intro__heading--has-tag">{ image.study_accession_id }:{ image.alias }<a href="JavaScript:Void(0);" class="vf-badge vf-badge--primary vf-badge--phases">alpha</a></h1>
+                <h1 class="vf-intro__heading vf-intro__heading--has-tag">{ image.study_accession_id }:{ image.alias }
+                    <WebsiteStateButton/>
+                </h1>
                 <h2 class="vf-intro__subheading">{image.name}</h2>
                 {image.original_relpath}
                 <p class="studytitle">{image.study_title}</p>

--- a/src/pages/galleries/spatialomics/dataset/[accessionID].astro
+++ b/src/pages/galleries/spatialomics/dataset/[accessionID].astro
@@ -1,5 +1,7 @@
 ---
 import BaseLayout from '../../../../layouts/BaseLayout.astro';
+import WebsiteStateButton from '../../../../components/WebsiteStateButton.astro';
+
 import exports from "../../../../data/old-export-format/bia-spatialomics-export.json";
 
 import studyImage from '../../../../assets/bioimage-archive/study.png';
@@ -29,7 +31,9 @@ const images = study.image_uuids.map((uuid) => exports["images"][uuid]);
     <section class="vf-intro | embl-grid embl-grid--has-centered-content">
         <div></div>
         <div>
-            <h1 class="vf-intro__heading vf-intro__heading--has-tag">{ study.accession_id }<a href="JavaScript:Void(0);" class="vf-badge vf-badge--primary vf-badge--phases">alpha</a></h1>
+            <h1 class="vf-intro__heading vf-intro__heading--has-tag">{ study.accession_id }
+              <WebsiteStateButton/>
+            </h1>
             <h2 class="vf-intro__subheading">{ study.title }</h2>
             Released { study.release_date }<br>
             <!-- {{ authors }} -->

--- a/src/pages/help/about-the-new-website.mdx
+++ b/src/pages/help/about-the-new-website.mdx
@@ -17,7 +17,7 @@ While this new site is under development, the existing [BioImage Archive](https:
 
 We are currently working on adding existing and incoming submissions to the alpha. In the meantime, they can all be found on the [current website](https://www.ebi.ac.uk/biostudies/BioImages/studies).
 
-We are also working on displaying images from every submission, but in the meantime you may see placeholders. Similarly, some studies will not have any files or images listed on their pages.
+We are also working on displaying images from most submissions, but in the meantime you may see placeholders. Similarly, some studies will not have any files or images listed on their pages.
 
 This website will undergo frequent updates as we get feedback, so pages may move and content may be replaced.
 

--- a/src/pages/help/about-the-new-website.mdx
+++ b/src/pages/help/about-the-new-website.mdx
@@ -1,13 +1,15 @@
 ---
-title: About this Alpha
+title: About the new BioImage-Archive website
 layout: ../../layouts/HelpLayout.astro
 
 ---
 
 
-## About this Alpha
+## About the new BioImage-Archive website
 
 Welcome to the alpha of the new BioImage-Archive website! 
+
+We have developed a complete new web interface to the BioImage Archive's data collections. This site provides an early opportunity to view images interactively, explore their contextual information and look at curated collections.
 
 ### What to expect
 
@@ -33,3 +35,8 @@ We are processing publicly released submissions to display on this alpha website
 
 #### Why does my submission not have any images/files/data?
 We do not yet automatically process files from submissions, nor turn them into images, in order to be displayed in this alpha. Submission data can be still be found on their study pages, which is linked to via the "Original Study" button on every submission. 
+
+### Website changelog
+
+2025/02/24 - Alpha release
+

--- a/src/pages/help/about-this-alpha.mdx
+++ b/src/pages/help/about-this-alpha.mdx
@@ -11,9 +11,13 @@ Welcome to the alpha of the new BioImage-Archive website!
 
 ### What to expect
 
+While this new site is under development, the existing [BioImage Archive](https://www.ebi.ac.uk/biostudies/BioImages/) site will still be actively maintainted.
+
 We are currently working on adding existing and incoming submissions to the alpha. In the meantime, they can all be found on the [current website](https://www.ebi.ac.uk/biostudies/BioImages/studies).
 
 We are also working on displaying images from every submission, but in the meantime you may see placeholders. Similarly, some studies will not have any files or images listed on their pages.
+
+This website will undergo frequent updates as we get feedback, so pages may move and content may be replaced.
 
 ### Feedback
 

--- a/src/pages/help/about-this-alpha.mdx
+++ b/src/pages/help/about-this-alpha.mdx
@@ -1,0 +1,31 @@
+---
+title: About this Alpha
+layout: ../../layouts/HelpLayout.astro
+
+---
+
+
+## About this Alpha
+
+Welcome to the alpha of the new BioImage-Archive website! 
+
+### What to expect
+
+We are currently working on adding existing and incoming submissions to the alpha. In the meantime, they can all be found on the [current website](https://www.ebi.ac.uk/biostudies/BioImages/studies).
+
+We are also working on displaying images from every submission, but in the meantime you may see placeholders. Similarly, some studies will not have any files or images listed on their pages.
+
+### Feedback
+
+We would love to hear your feedback on the alpha, as this will help guide and prioritise future development of the BioImage Archive. Please send feedback, both positive and negative, by emailing us at: bioimage-archive@ebi.ac.uk
+
+### Alpha FAQ
+
+#### How long will the website be in alpha?
+We are yet to announce a date for the end of the alpha.
+
+#### Why is my submission not being displayed?
+We are processing publicly released submissions to display on this alpha website, but we do not yet automatically process studies. Submissions that do not follow our standard template require additional conversion, but they will eventually make it to the alpha.
+
+#### Why does my submission not have any images/files/data?
+We do not yet automatically process files from submissions, nor turn them into images, in order to be displayed in this alpha. Submission data can be still be found on their study pages, which is linked to via the "Original Study" button on every submission. 

--- a/src/pages/image/[uuid].astro
+++ b/src/pages/image/[uuid].astro
@@ -2,6 +2,7 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import SourceImage from "../../components/SourceImage.astro"
 import DatasetDetail from '../../components/DatasetDetail.astro';
+import WebsiteStateButton from '../../components/WebsiteStateButton.astro';
 
 import fieldMap from "../../data/metadata-field-name-mapping.json";
 import datasetMetadata from "../../data/bia-dataset-metadata-for-images.json";
@@ -119,7 +120,10 @@ const displayImageHTML = vizarrIFrameSource ? `<iframe style="width: 100%; heigh
         <section class="vf-content | embl-grid embl-grid--has-centered-content">
             <div></div>
             <div>
-                <h1 class="vf-intro__heading vf-intro__heading--has-tag">{ imageStudy.accession_id }<a href="JavaScript:Void(0);" class="vf-badge vf-badge--primary vf-badge--phases">alpha</a></h1>
+                <h1 class="vf-intro__heading vf-intro__heading--has-tag">
+                    { imageStudy.accession_id }
+                    <WebsiteStateButton/>
+                </h1>
                 <h2 class="vf-intro__subheading">{imageStudy.title}</h2>
                 <p class="studytitle">{imageDataset.title_id}</p>
                 <a href={ "/bioimage-archive/dataset/" + imageStudy.accession_id}>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -208,9 +208,11 @@ import MenuCard from "../components/cards/LandingPageMenuCard.astro";
   <section class="vf-u-fullbleed" style="background-color: #3b6fb6; margin: 0px">
     <div
         class="vf-content"
-        style="background-color: #3b6fb6; margin: 0px 10%; padding: 24px 0px; color: #ffffff"
+        style="margin: 0px 10%; padding: 24px 0px;"
       >
-          Welcome to the Alpha version of the BIA website. <a href="/bioimage-archive/help/about-this-alpha" style="color: #ffffff"> Click here</a> to learn more about the alpha.
+      <h3 style=" color: #ffffff; margin: 0px;">
+        Welcome to the Alpha version of the BIA website. <a href="/bioimage-archive/help/about-this-alpha" style="color: #ffffff"> Click here</a> to learn more about the alpha.
+      </h3>
     </div>
   </section>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -211,7 +211,7 @@ import MenuCard from "../components/cards/LandingPageMenuCard.astro";
         style="margin: 0px 10%; padding: 24px 0px;"
       >
       <h3 style=" color: #ffffff; margin: 0px;">
-        Welcome to the Alpha version of the BIA website. <a href="/bioimage-archive/help/about-this-alpha" style="color: #ffffff"> Click here</a> to learn more about the alpha.
+        Welcome to the Alpha version of the BIA website. <a href="/bioimage-archive/help/about-the-new-website" style="color: #ffffff"> Click here</a> to learn more about the alpha.
       </h3>
     </div>
   </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -204,6 +204,16 @@ import MenuCard from "../components/cards/LandingPageMenuCard.astro";
     </section>
   </body>
 
+
+  <section class="vf-u-fullbleed" style="background-color: #3b6fb6; margin: 0px">
+    <div
+        class="vf-content"
+        style="background-color: #3b6fb6; margin: 0px 10%; padding: 24px 0px; color: #ffffff"
+      >
+          Welcome to the Alpha version of the BIA website. <a href="/bioimage-archive/help/about-this-alpha" style="color: #ffffff"> Click here</a> to learn more about the alpha.
+    </div>
+  </section>
+
   <section
     class="vf-grid vf-grid__col-3 | vf-card-container | vf-u-fullbleed"
     style="margin-left: 10%; margin-right: 10%;"


### PR DESCRIPTION
TODO: i want to make the 'ALPHA' buttons that exist on every study etc. page either:
1. link to the about this alpha help page
2. have some hover-over / popup information along the same lines
Please comment on preffered approaches.