### PR TITLE
fixed file count retrieval so dataset files table is now working again

### DIFF
--- a/src/pages/dataset/[accessionID].astro
+++ b/src/pages/dataset/[accessionID].astro
@@ -43,10 +43,10 @@ function getStudyImage(study) {
   }
 }
 
-function getDatasetStatsByUUID(study_info) {
+function getDatasetStatsByUUID(study) {
   const dataset_uuids = []
-  for (var dataset of study_info.dataset) {
-    dataset_uuids.push([dataset.uuid,dataset.file_count,dataset.title_id])
+  for (var dataset of study.dataset) {
+    dataset_uuids.push([dataset.uuid,dataset.file_reference_count,dataset.title_id])
   }
   return dataset_uuids
 }
@@ -55,7 +55,7 @@ const datasetUUIDsAndFileStats = getDatasetStatsByUUID(study)
 
 const totalImageCount = study.dataset.reduce((accumulator, dataset) => accumulator + dataset.image_count, 0);
 
-const totalFileCount = study.dataset.reduce((accumulator, dataset) => accumulator + dataset.file_count, 0);
+const totalFileCount = study.dataset.reduce((accumulator, dataset) => accumulator + dataset.file_reference_count, 0);
 
 function getFileTypes(study) {
     const fileTypeList = []


### PR DESCRIPTION
Noticed Dataset Files table wasn't showing files as file_count variable name had changed. fixed it so it's working again.