### PR TITLE
Make table links nicer

### DIFF
--- a/src/components/ai-benchmarking/ModelPredictionTable.astro
+++ b/src/components/ai-benchmarking/ModelPredictionTable.astro
@@ -66,6 +66,7 @@ const hasReferenceImage = tableRows.filter(row => row.annotation_data_set_uuid !
                             <a href={row.example_image} target="_blank" rel="noopener noreferrer">
                                 <img src={row.example_image} style="max-width: 180px; max-height: 180px;"/>
                             </a>
+                            <br/>
                             <a href={row.example_image} download>
                                     Download
                             </a>
@@ -78,6 +79,7 @@ const hasReferenceImage = tableRows.filter(row => row.annotation_data_set_uuid !
                                     <a href={row.example_ground_truth} target="_blank" rel="noopener noreferrer">
                                         <img src={row.example_ground_truth} style="max-width: 180px; max-height: 180px;"/>
                                     </a>
+                                    <br/>
                                     <a href={row.example_ground_truth} download>
                                         Download 
                                     </a>
@@ -90,6 +92,7 @@ const hasReferenceImage = tableRows.filter(row => row.annotation_data_set_uuid !
                             <a href={row.example_process_image} target="_blank" rel="noopener noreferrer">
                                 <img src={row.example_process_image} style="max-width: 180px; max-height: 180px;"/>
                             </a>
+                            <br/>
                             <a href={row.example_process_image} download >
                                 Download 
                             </a> 

--- a/src/pages/dataset/[accessionID].astro
+++ b/src/pages/dataset/[accessionID].astro
@@ -27,12 +27,12 @@ const tableOfContents = {
 const { accessionID } = Astro.params;
 const study = accessionID in studyMetadata ? studyMetadata[accessionID] : undefined;
 
-const images = []
-for (var dataset of study.dataset) {
-  for (var image of dataset.image) {
-    images.push(image)
-  }
-}
+const images = study.dataset.flatMap(dataset => dataset.image ?? [])
+// for (var dataset of study.dataset) {
+//   for (var image of dataset.image) {
+//     images.push(image)
+//   }
+// }
 
 function getStudyImage(study) {
   const datasetWithImage = study.dataset.find((dataset) => dataset.example_image_uri.length > 0)
@@ -218,7 +218,11 @@ const headlineStats = {
                         columns: [
                             { data: "uuid", title: "File UUID" },
                             { data: "file_path", title: "File Name" },
-                            { data: "uri", title: "Link" },
+                            { 
+                              data: "uri", 
+                              title: "Actions", 
+                              render: (data) => `<button class="copy-btn" data-uri="${data}">Copy Url</button>` 
+                            },
                         ],
                         pageLength: 25, 
                         searching: true,
@@ -226,6 +230,18 @@ const headlineStats = {
                         processing: true,
                         scrollX: true,
                         columnDefs: [{ type: "natural", targets: 0 }],
+                        createdRow: (row, data) => {
+                            // Attach event listener to the button after row creation
+                            $(row).find(".copy-btn").on("click", function () {
+                                const link = $(this).data("uri");
+                                navigator.clipboard.writeText(link).then(() => {
+                                  this.innerText = "URL Copied";
+                                  setTimeout(() => {
+                                      this.innerText = "Copy Url";
+                                  }, 700);
+                                });
+                            });
+                        }
                     });
                 })
                 .catch((error) => {


### PR DESCRIPTION
2 changes

Main change: Make tables look a bit nicer with url buttons rather than super long urls in a links column
Ticket: https://app.clickup.com/t/8697y39b2
E.g: https://deploy-preview-71--bia-beta-website.netlify.app/bioimage-archive/dataset/s-biad830/ 

Bonus extra change (totally not scope creep) 
Add breaks to AI tables to make sure download button appears below images (rather than next to them, when images are weirdly shapes). This is more likely to happen on the old style website, but keeping them consistent code & output wise makes life easier. 
E.g: Bottom table from: https://deploy-preview-71--bia-beta-website.netlify.app/bioimage-archive/galleries/ai/model/noisy-fish/ 