### PR TITLE
render annotation and source image

### DIFF
--- a/src/data/current-export-mock/bia-ai-dataset-export.json
+++ b/src/data/current-export-mock/bia-ai-dataset-export.json
@@ -1,0 +1,697 @@
+{
+    "45cf5aba-ac83-4a91-8e84-9836462136a8": {
+        "object_creator": "bia_ingest",
+        "uuid": "45cf5aba-ac83-4a91-8e84-9836462136a8",
+        "version": 0,
+        "model": {
+            "type_name": "Dataset",
+            "version": 2
+        },
+        "additional_metadata": [
+            {
+                "provenance": "bia_ingest",
+                "name": "associations",
+                "value": {
+                    "associations": [
+                        {
+                            "image_analysis": null,
+                            "image_correlation": null,
+                            "biosample": "Tumor sample from ganglioneuroblastoma patient",
+                            "image_acquisition": "Fluorescence imaging",
+                            "specimen": "Preparation and IF-staining of tumor tissue cryosections"
+                        },
+                        {
+                            "image_analysis": null,
+                            "image_correlation": null,
+                            "biosample": "Tumor sample from neuroblastoma patient",
+                            "image_acquisition": "Fluorescence imaging",
+                            "specimen": "Preparation and IF-staining of tumor tissue cryosections"
+                        },
+                        {
+                            "image_analysis": null,
+                            "image_correlation": null,
+                            "biosample": "Tumor sample from Wilms tumor patient",
+                            "image_acquisition": "Fluorescence imaging",
+                            "specimen": "Preparation and IF-staining of tumor tissue cryosections"
+                        },
+                        {
+                            "image_analysis": null,
+                            "image_correlation": null,
+                            "biosample": "Skin keratinocyte cell line",
+                            "image_acquisition": "Fluorescence imaging",
+                            "specimen": "Preparation and IF-staining of HaCaT human skin keratinocyte cell line"
+                        },
+                        {
+                            "image_analysis": null,
+                            "image_correlation": null,
+                            "biosample": "Tumor sample from neuroblastoma patient",
+                            "image_acquisition": "Fluorescence imaging",
+                            "specimen": "Preparation and IF-staining of tumor touch imprints and bone marrow cytospin preparations"
+                        },
+                        {
+                            "image_analysis": null,
+                            "image_correlation": null,
+                            "biosample": "Bone marrow sample from neuroblastoma patient",
+                            "image_acquisition": "Fluorescence imaging",
+                            "specimen": "Preparation and IF-staining of tumor touch imprints and bone marrow cytospin preparations"
+                        },
+                        {
+                            "image_analysis": null,
+                            "image_correlation": null,
+                            "biosample": "Neuroblastoma cell lines",
+                            "image_acquisition": "Fluorescence imaging",
+                            "specimen": "Preparation and IF-staining of neuroblastoma cell line cytospin preparations"
+                        }
+                    ]
+                }
+            },
+            {
+                "provenance": "bia_ingest",
+                "name": "image_acquisition_protocol_uuid",
+                "value": {
+                    "image_acquisition_protocol_uuid": [
+                        "29f61c5f-ae01-438d-8aa0-d9a787751443"
+                    ]
+                }
+            },
+            {
+                "provenance": "bia_ingest",
+                "name": "specimen_imaging_preparation_protocol_uuid",
+                "value": {
+                    "specimen_imaging_preparation_protocol_uuid": [
+                        "65dec4db-20e8-4505-83a7-6b73a43c64db",
+                        "fa9836ff-dfe2-4bb9-af81-ee450b028a30",
+                        "6b8fd66c-20bc-4cea-9bca-8411965dd7f4",
+                        "a4dad3fc-be06-467a-a52f-bb672e3c623f"
+                    ]
+                }
+            },
+            {
+                "provenance": "bia_ingest",
+                "name": "bio_sample_uuid",
+                "value": {
+                    "bio_sample_uuid": [
+                        "c8c7e2ad-1cf4-49b2-b2a0-1cb033c63dbf",
+                        "f29b5a91-69f1-4921-8d8f-e62ce493c523",
+                        "5fbed112-60d9-4777-83ba-139fa170c05f",
+                        "819dc124-caa5-4fa1-bf99-e47a784b75f0",
+                        "45e124c5-edd3-492b-8f9b-580e7834c623",
+                        "073010c8-ac4d-44ee-a541-0bdaf68cb46c"
+                    ]
+                }
+            },
+            {
+                "provenance": "bia_ingest",
+                "name": "uuid_unique_input",
+                "value": {
+                    "uuid_unique_input": "Study Component-6"
+                }
+            }
+        ],
+        "title": "Fluorescence images",
+        "description": "Fluorescent nuclear images of normal or cancer cells from different tissue origins and sample preparation types",
+        "analysis_method": [],
+        "correlation_method": [],
+        "example_image_uri": [],
+        "submitted_in_study_uuid": "0ea2dc40-bf51-4ff8-82e9-2e4cbd8efd71",
+        "submitted_in_study": {
+            "object_creator": "bia_ingest",
+            "uuid": "0ea2dc40-bf51-4ff8-82e9-2e4cbd8efd71",
+            "version": 0,
+            "model": {
+                "type_name": "Study",
+                "version": 3
+            },
+            "additional_metadata": [
+                {
+                    "provenance": "bia_ingest",
+                    "name": "biostudies json/pagetab entry",
+                    "value": {
+                        "json": "https://www.ebi.ac.uk/biostudies/files/S-BIAD634/S-BIAD634.json",
+                        "pagetab": "https://www.ebi.ac.uk/biostudies/files/S-BIAD634/S-BIAD634.tsv"
+                    }
+                }
+            ],
+            "accession_id": "S-BIAD634",
+            "licence": "https://creativecommons.org/publicdomain/zero/1.0/",
+            "author": [
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "orcid": "0000-0002-1439-5301",
+                    "display_name": "Sabine Taschner-Mandl",
+                    "affiliation": [
+                        {
+                            "rorid": null,
+                            "address": null,
+                            "website": null,
+                            "display_name": "Children's Cancer Research Institute"
+                        }
+                    ],
+                    "contact_email": "sabine.taschner@ccri.at",
+                    "role": [
+                        "conceptualization",
+                        "data acquisition"
+                    ]
+                },
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "orcid": null,
+                    "display_name": "Inge M. Ambros",
+                    "affiliation": [
+                        {
+                            "rorid": null,
+                            "address": null,
+                            "website": null,
+                            "display_name": "Children's Cancer Research Institute"
+                        }
+                    ],
+                    "contact_email": "inge.ambros@ccri.at",
+                    "role": [
+                        "data acquisition",
+                        "data annotation"
+                    ]
+                },
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "orcid": "0000-0002-5507-7211",
+                    "display_name": "Peter F. Ambros",
+                    "affiliation": [
+                        {
+                            "rorid": null,
+                            "address": null,
+                            "website": null,
+                            "display_name": "Children's Cancer Research Institute"
+                        }
+                    ],
+                    "contact_email": "peter.ambros@ccri.at",
+                    "role": [
+                        "conceptualization",
+                        "data acquisition"
+                    ]
+                },
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "orcid": null,
+                    "display_name": "Klaus Beiske",
+                    "affiliation": [
+                        {
+                            "rorid": null,
+                            "address": null,
+                            "website": null,
+                            "display_name": "Oslo University Hospital"
+                        }
+                    ],
+                    "contact_email": "klaus.beiske@medisin.uio.no",
+                    "role": [
+                        "data annotation"
+                    ]
+                },
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "orcid": "0000-0002-7149-5843",
+                    "display_name": "Allan  Hanbury",
+                    "affiliation": [
+                        {
+                            "rorid": null,
+                            "address": null,
+                            "website": null,
+                            "display_name": "TU Wien"
+                        }
+                    ],
+                    "contact_email": "hanbury@ifs.tuwien.ac.at",
+                    "role": [
+                        "conceptualization"
+                    ]
+                },
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "orcid": "0000-0003-1477-6849",
+                    "display_name": "Wolfgang Doerr",
+                    "affiliation": [
+                        {
+                            "rorid": null,
+                            "address": null,
+                            "website": null,
+                            "display_name": "TRAB-Applied and Translational Radiobiology, Department of Radiation Oncology, Medical University of Vienna"
+                        }
+                    ],
+                    "contact_email": "wolfgang.doerr@meduniwien.ac.at",
+                    "role": [
+                        "resources"
+                    ]
+                },
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "orcid": "0000-0001-7046-3412",
+                    "display_name": "Tamara Weiss",
+                    "affiliation": [
+                        {
+                            "rorid": null,
+                            "address": null,
+                            "website": null,
+                            "display_name": "Children's Cancer Research Institute"
+                        }
+                    ],
+                    "contact_email": "tamara.weiss@meduniwien.ac.at",
+                    "role": [
+                        "data acquisition",
+                        "data annotation"
+                    ]
+                },
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "orcid": null,
+                    "display_name": "Maria Berneder",
+                    "affiliation": [
+                        {
+                            "rorid": null,
+                            "address": null,
+                            "website": null,
+                            "display_name": "Children's Cancer Research Institute"
+                        }
+                    ],
+                    "contact_email": "maria.berneder@ccri.at",
+                    "role": [
+                        "sample preparation"
+                    ]
+                },
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "orcid": null,
+                    "display_name": "Magdalena Ambros",
+                    "affiliation": [
+                        {
+                            "rorid": null,
+                            "address": null,
+                            "website": null,
+                            "display_name": "Children's Cancer Research Institute"
+                        }
+                    ],
+                    "contact_email": "magdalena.ambros@ccri.at",
+                    "role": [
+                        "data acquisition"
+                    ]
+                },
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "orcid": null,
+                    "display_name": "Eva Bozsaky",
+                    "affiliation": [
+                        {
+                            "rorid": null,
+                            "address": null,
+                            "website": null,
+                            "display_name": "Children's Cancer Research Institute"
+                        }
+                    ],
+                    "contact_email": "eva.bozsaky@ccri.at",
+                    "role": [
+                        "data acquisition",
+                        "data annotation"
+                    ]
+                },
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "orcid": "0000-0003-4557-5652",
+                    "display_name": "Florian Kromp",
+                    "affiliation": [
+                        {
+                            "rorid": null,
+                            "address": null,
+                            "website": null,
+                            "display_name": "Children's Cancer Research Institute"
+                        }
+                    ],
+                    "contact_email": "florian.kromp@ccri.at",
+                    "role": [
+                        "conceptualization",
+                        "data acquisition",
+                        "data annotation",
+                        "data analysis"
+                    ]
+                },
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "orcid": "0000-0002-0456-6912",
+                    "display_name": "Teresa Zulueta-Coarasa",
+                    "affiliation": [
+                        {
+                            "rorid": null,
+                            "address": null,
+                            "website": null,
+                            "display_name": "European Bioinformatics Institute (EMBL-EBI)"
+                        }
+                    ],
+                    "contact_email": "teresaz@ebi.ac.uk",
+                    "role": [
+                        "data curation"
+                    ]
+                }
+            ],
+            "title": "An annotated fluorescence image dataset for training nuclear segmentation methods",
+            "release_date": "2023-03-07",
+            "description": "This dataset contains annotated fluorescent nuclear images of normal or cancer cells from different tissue origins and sample preparation types, and can be used to train machine-learning based nuclear image segmentation algorithms. It consists of 79 expert-annotated fluorescence images of immuno and DAPI stained samples containing 7813 nuclei in total. In addition, the dataset is heterogenous in aspects such as type of preparation, imaging modality, magnification, signal-to-noise ratio and other technical aspects. Relevant parameters, e.g. diagnosis, magnification, signal-to-noise ratio and modality with respect to the type of preparation are provided in the file list. The images are derived from one Schwann cell stroma-rich tissue (from a ganglioneuroblastoma) cryosection (10 images/2773 nuclei), seven neuroblastoma (NB) patients (19 images/931 nuclei), one Wilms patient (1 image/102 nuclei), two NB cell lines (CLB-Ma, STA-NB10) (8 images/1785 nuclei) and a human keratinocyte cell line (HaCaT) (41 images/2222 nuclei).",
+            "keyword": [
+                "AI",
+                "segmentation",
+                "nucleus",
+                "fluorescence"
+            ],
+            "acknowledgement": "",
+            "see_also": [],
+            "related_publication": [],
+            "grant": [],
+            "funding_statement": "This work was facilitated by an EraSME grant (project TisQuant) under the grant no. 844198 and by a COIN grant (project VISIOMICS) under the grant no. 861750, both grants kindly provided by the Austrian Research Promotion Agency (FFG), and the St. Anna Kinderkrebsforschung. Partial funding was further provided by BMK, BMDW, and the Province of Upper Austria in the frame of the COMET Programme managed by FFG."
+        }
+    },
+    "b861c692-68f8-4c41-b583-162d4a44f793": {
+        "object_creator": "bia_ingest",
+        "uuid": "b861c692-68f8-4c41-b583-162d4a44f793",
+        "version": 0,
+        "model": {
+            "type_name": "Dataset",
+            "version": 2
+        },
+        "additional_metadata": [
+            {
+                "provenance": "bia_ingest",
+                "name": "annotation_method_uuid",
+                "value": {
+                    "annotation_method_uuid": [
+                        "66139451-bcbe-475b-8c4b-1aa6dd0cf498"
+                    ]
+                }
+            },
+            {
+                "provenance": "bia_ingest",
+                "name": "uuid_unique_input",
+                "value": {
+                    "uuid_unique_input": "Annotations-29"
+                }
+            }
+        ],
+        "title": "Segmentation masks",
+        "description": null,
+        "analysis_method": [],
+        "correlation_method": [],
+        "example_image_uri": [],
+        "submitted_in_study_uuid": "0ea2dc40-bf51-4ff8-82e9-2e4cbd8efd71",
+        "submitted_in_study": {
+            "object_creator": "bia_ingest",
+            "uuid": "0ea2dc40-bf51-4ff8-82e9-2e4cbd8efd71",
+            "version": 0,
+            "model": {
+                "type_name": "Study",
+                "version": 3
+            },
+            "additional_metadata": [
+                {
+                    "provenance": "bia_ingest",
+                    "name": "biostudies json/pagetab entry",
+                    "value": {
+                        "json": "https://www.ebi.ac.uk/biostudies/files/S-BIAD634/S-BIAD634.json",
+                        "pagetab": "https://www.ebi.ac.uk/biostudies/files/S-BIAD634/S-BIAD634.tsv"
+                    }
+                }
+            ],
+            "accession_id": "S-BIAD634",
+            "licence": "https://creativecommons.org/publicdomain/zero/1.0/",
+            "author": [
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "orcid": "0000-0002-1439-5301",
+                    "display_name": "Sabine Taschner-Mandl",
+                    "affiliation": [
+                        {
+                            "rorid": null,
+                            "address": null,
+                            "website": null,
+                            "display_name": "Children's Cancer Research Institute"
+                        }
+                    ],
+                    "contact_email": "sabine.taschner@ccri.at",
+                    "role": [
+                        "conceptualization",
+                        "data acquisition"
+                    ]
+                },
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "orcid": null,
+                    "display_name": "Inge M. Ambros",
+                    "affiliation": [
+                        {
+                            "rorid": null,
+                            "address": null,
+                            "website": null,
+                            "display_name": "Children's Cancer Research Institute"
+                        }
+                    ],
+                    "contact_email": "inge.ambros@ccri.at",
+                    "role": [
+                        "data acquisition",
+                        "data annotation"
+                    ]
+                },
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "orcid": "0000-0002-5507-7211",
+                    "display_name": "Peter F. Ambros",
+                    "affiliation": [
+                        {
+                            "rorid": null,
+                            "address": null,
+                            "website": null,
+                            "display_name": "Children's Cancer Research Institute"
+                        }
+                    ],
+                    "contact_email": "peter.ambros@ccri.at",
+                    "role": [
+                        "conceptualization",
+                        "data acquisition"
+                    ]
+                },
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "orcid": null,
+                    "display_name": "Klaus Beiske",
+                    "affiliation": [
+                        {
+                            "rorid": null,
+                            "address": null,
+                            "website": null,
+                            "display_name": "Oslo University Hospital"
+                        }
+                    ],
+                    "contact_email": "klaus.beiske@medisin.uio.no",
+                    "role": [
+                        "data annotation"
+                    ]
+                },
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "orcid": "0000-0002-7149-5843",
+                    "display_name": "Allan  Hanbury",
+                    "affiliation": [
+                        {
+                            "rorid": null,
+                            "address": null,
+                            "website": null,
+                            "display_name": "TU Wien"
+                        }
+                    ],
+                    "contact_email": "hanbury@ifs.tuwien.ac.at",
+                    "role": [
+                        "conceptualization"
+                    ]
+                },
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "orcid": "0000-0003-1477-6849",
+                    "display_name": "Wolfgang Doerr",
+                    "affiliation": [
+                        {
+                            "rorid": null,
+                            "address": null,
+                            "website": null,
+                            "display_name": "TRAB-Applied and Translational Radiobiology, Department of Radiation Oncology, Medical University of Vienna"
+                        }
+                    ],
+                    "contact_email": "wolfgang.doerr@meduniwien.ac.at",
+                    "role": [
+                        "resources"
+                    ]
+                },
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "orcid": "0000-0001-7046-3412",
+                    "display_name": "Tamara Weiss",
+                    "affiliation": [
+                        {
+                            "rorid": null,
+                            "address": null,
+                            "website": null,
+                            "display_name": "Children's Cancer Research Institute"
+                        }
+                    ],
+                    "contact_email": "tamara.weiss@meduniwien.ac.at",
+                    "role": [
+                        "data acquisition",
+                        "data annotation"
+                    ]
+                },
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "orcid": null,
+                    "display_name": "Maria Berneder",
+                    "affiliation": [
+                        {
+                            "rorid": null,
+                            "address": null,
+                            "website": null,
+                            "display_name": "Children's Cancer Research Institute"
+                        }
+                    ],
+                    "contact_email": "maria.berneder@ccri.at",
+                    "role": [
+                        "sample preparation"
+                    ]
+                },
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "orcid": null,
+                    "display_name": "Magdalena Ambros",
+                    "affiliation": [
+                        {
+                            "rorid": null,
+                            "address": null,
+                            "website": null,
+                            "display_name": "Children's Cancer Research Institute"
+                        }
+                    ],
+                    "contact_email": "magdalena.ambros@ccri.at",
+                    "role": [
+                        "data acquisition"
+                    ]
+                },
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "orcid": null,
+                    "display_name": "Eva Bozsaky",
+                    "affiliation": [
+                        {
+                            "rorid": null,
+                            "address": null,
+                            "website": null,
+                            "display_name": "Children's Cancer Research Institute"
+                        }
+                    ],
+                    "contact_email": "eva.bozsaky@ccri.at",
+                    "role": [
+                        "data acquisition",
+                        "data annotation"
+                    ]
+                },
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "orcid": "0000-0003-4557-5652",
+                    "display_name": "Florian Kromp",
+                    "affiliation": [
+                        {
+                            "rorid": null,
+                            "address": null,
+                            "website": null,
+                            "display_name": "Children's Cancer Research Institute"
+                        }
+                    ],
+                    "contact_email": "florian.kromp@ccri.at",
+                    "role": [
+                        "conceptualization",
+                        "data acquisition",
+                        "data annotation",
+                        "data analysis"
+                    ]
+                },
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "orcid": "0000-0002-0456-6912",
+                    "display_name": "Teresa Zulueta-Coarasa",
+                    "affiliation": [
+                        {
+                            "rorid": null,
+                            "address": null,
+                            "website": null,
+                            "display_name": "European Bioinformatics Institute (EMBL-EBI)"
+                        }
+                    ],
+                    "contact_email": "teresaz@ebi.ac.uk",
+                    "role": [
+                        "data curation"
+                    ]
+                }
+            ],
+            "title": "An annotated fluorescence image dataset for training nuclear segmentation methods",
+            "release_date": "2023-03-07",
+            "description": "This dataset contains annotated fluorescent nuclear images of normal or cancer cells from different tissue origins and sample preparation types, and can be used to train machine-learning based nuclear image segmentation algorithms. It consists of 79 expert-annotated fluorescence images of immuno and DAPI stained samples containing 7813 nuclei in total. In addition, the dataset is heterogenous in aspects such as type of preparation, imaging modality, magnification, signal-to-noise ratio and other technical aspects. Relevant parameters, e.g. diagnosis, magnification, signal-to-noise ratio and modality with respect to the type of preparation are provided in the file list. The images are derived from one Schwann cell stroma-rich tissue (from a ganglioneuroblastoma) cryosection (10 images/2773 nuclei), seven neuroblastoma (NB) patients (19 images/931 nuclei), one Wilms patient (1 image/102 nuclei), two NB cell lines (CLB-Ma, STA-NB10) (8 images/1785 nuclei) and a human keratinocyte cell line (HaCaT) (41 images/2222 nuclei).",
+            "keyword": [
+                "AI",
+                "segmentation",
+                "nucleus",
+                "fluorescence"
+            ],
+            "acknowledgement": "",
+            "see_also": [],
+            "related_publication": [],
+            "grant": [],
+            "funding_statement": "This work was facilitated by an EraSME grant (project TisQuant) under the grant no. 844198 and by a COIN grant (project VISIOMICS) under the grant no. 861750, both grants kindly provided by the Austrian Research Promotion Agency (FFG), and the St. Anna Kinderkrebsforschung. Partial funding was further provided by BMK, BMDW, and the Province of Upper Austria in the frame of the COMET Programme managed by FFG."
+        }
+    }
+}

--- a/src/data/current-export-mock/bia-ai-image-export.json
+++ b/src/data/current-export-mock/bia-ai-image-export.json
@@ -1,0 +1,1616 @@
+{
+    "15e5f46d-369b-49cf-9fda-15c0d0ed67ab": {
+        "object_creator": "bia_image_assignment",
+        "uuid": "15e5f46d-369b-49cf-9fda-15c0d0ed67ab",
+        "version": 1,
+        "model": {
+            "type_name": "Image",
+            "version": 2
+        },
+        "additional_metadata": [
+            {
+                "provenance": "bia_image_assignment",
+                "name": "attributes_from_file_reference_2d7824e6-c2ee-47c9-98a9-8b26f032ebf8",
+                "value": {
+                    "attributes": {
+                        "file description": "Raw nuclear images in TIFF format",
+                        "Diagnosis": "normal (HaCaT)",
+                        "Preparation": "cellline cytospin",
+                        "Train-/Testset split": "train",
+                        "Testset class": "-",
+                        "Magnification": "63x",
+                        "Modality": "FM",
+                        "Device": "Zeiss Axioplan II",
+                        "Software": "Metafer",
+                        "Mean BG signal": "19,4",
+                        "Mean FG signal": "130,4",
+                        "Signal/Noise": "6,7",
+                        "S/N Class": ">=4,<40"
+                    }
+                }
+            },
+            {
+                "provenance": "bia_image_assignment",
+                "name": "file_pattern",
+                "value": {
+                    "file_pattern": "dataset/rawimages/normal_20.tif"
+                }
+            },
+            {
+                "provenance": "bia_image_assignment",
+                "name": "uuid_unique_input",
+                "value": {
+                    "uuid_unique_input": "2d7824e6-c2ee-47c9-98a9-8b26f032ebf8"
+                }
+            },
+            {
+                "provenance": "bia_image_assignment",
+                "name": "thumbnail_uri",
+                "value": {
+                    "thumbnail_uri": [
+                        "https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD634/886609a6-1a98-4e32-9776-e2a9a4d3ba17/71e7fdd3-14e2-42b5-97f3-cce1af12492c.png"
+                    ]
+                }
+            },
+            {
+                "provenance": "bia_image_assignment",
+                "name": "recommended_vizarr_representation",
+                "value": {
+                    "recommended_vizarr_representation": "bfa4a4d2-0873-4f45-b1c3-4125f82ea650"
+                }
+            }
+        ],
+        "label": null,
+        "submission_dataset_uuid": "45cf5aba-ac83-4a91-8e84-9836462136a8",
+        "creation_process_uuid": "fdff0424-6f45-48dc-b176-20d266a74bb3",
+        "original_file_reference_uuid": [
+            "2d7824e6-c2ee-47c9-98a9-8b26f032ebf8"
+        ],
+        "creation_process": {
+            "object_creator": "bia_image_assignment",
+            "uuid": "fdff0424-6f45-48dc-b176-20d266a74bb3",
+            "version": 0,
+            "model": {
+                "type_name": "CreationProcess",
+                "version": 3
+            },
+            "additional_metadata": [
+                {
+                    "provenance": "bia_image_assignment",
+                    "name": "uuid_unique_input",
+                    "value": {
+                        "uuid_unique_input": "15e5f46d-369b-49cf-9fda-15c0d0ed67ab"
+                    }
+                }
+            ],
+            "subject_specimen_uuid": "a5e91bf4-82bc-4ebc-b312-66bfe8b0f4d1",
+            "image_acquisition_protocol_uuid": [
+                "29f61c5f-ae01-438d-8aa0-d9a787751443"
+            ],
+            "input_image_uuid": [],
+            "protocol_uuid": [],
+            "annotation_method_uuid": [],
+            "acquisition_process": [
+                {
+                    "default_open": true,
+                    "object_creator": "bia_ingest",
+                    "uuid": "29f61c5f-ae01-438d-8aa0-d9a787751443",
+                    "version": 0,
+                    "model": {
+                        "type_name": "ImageAcquisitionProtocol",
+                        "version": 3
+                    },
+                    "additional_metadata": [
+                        {
+                            "provenance": "bia_ingest",
+                            "name": "uuid_unique_input",
+                            "value": {
+                                "uuid_unique_input": "Image acquisition-3"
+                            }
+                        }
+                    ],
+                    "title": "Fluorescence imaging",
+                    "protocol_description": "Samples were imaged using 1. an Axioplan-II microscope from Zeiss equipped with a Maerzhaeuser slide scanning stage and a Metasystems Coolcube 1 camera using the Metafer software system (V3.8.6) from Metasystems, 2. an Axioplan-II microscope from Zeiss equipped with a Zeiss AxioCam Mrm 1 using the Metasystems ISIS Software for microscopy image acquisition, 3. an LSM 780 microscope from Zeiss equipped with an Argonlaser 458\u2009nm, a photomultiplier tube (PMT) detector (371\u2013740\u2009nm) and a motorized Piezo Z-stage using the Zeiss Zen software package and 4. a SP8X from Leica equipped with a Diode Laser and a PMT detector (447\u2013468\u2009nm). For the presented dataset, we digitized the DAPI staining pattern representing nuclear DNA. Additional immunofluorescence or FISH stainings were in part available. An automatic illumination time was set as measured by pixel saturation (Metasystems Metafer and ISIS) or defined manually (Zeiss and Leica LSMs). Objectives used were a Zeiss Plan-Apochromat 10\u00d7 objective (Zeiss Axioplan II; numerical aperture 0.45; air), a Zeiss 20\u00d7 Plan-Apochromat (Zeiss LSM 780; numerical aperture 0.8; oil), a Zeiss 20\u00d7 Plan-Apochromat (Leica SP8X; nuermical aperture 0.75; oil), a Zeiss Plan-Neofluar 40\u00d7 objective (Zeiss Axioplan II; numerical aperture 0.75) and a Zeiss Plan-Apochromat 63\u00d7 objective (Zeiss Axioplan II, Zeiss LSM 780 and Leica SP8X; numerical aperture 1.4; oil). Representative field of views (FOVs) were selected according to the following quality criteria: sharpness, intact nuclei and a sufficient number of nuclei.",
+                    "imaging_instrument_description": "Axioplan-II microscope from Zeiss, LSM 780 microscope from Zeiss, SP8X from Leica",
+                    "fbbi_id": [],
+                    "imaging_method_name": [
+                        "fluorescence microscopy"
+                    ]
+                }
+            ],
+            "subject": {
+                "object_creator": "bia_image_assignment",
+                "uuid": "a5e91bf4-82bc-4ebc-b312-66bfe8b0f4d1",
+                "version": 0,
+                "model": {
+                    "type_name": "Specimen",
+                    "version": 3
+                },
+                "additional_metadata": [
+                    {
+                        "provenance": "bia_image_assignment",
+                        "name": "uuid_unique_input",
+                        "value": {
+                            "uuid_unique_input": "15e5f46d-369b-49cf-9fda-15c0d0ed67ab"
+                        }
+                    }
+                ],
+                "imaging_preparation_protocol_uuid": [
+                    "65dec4db-20e8-4505-83a7-6b73a43c64db",
+                    "fa9836ff-dfe2-4bb9-af81-ee450b028a30",
+                    "6b8fd66c-20bc-4cea-9bca-8411965dd7f4",
+                    "a4dad3fc-be06-467a-a52f-bb672e3c623f"
+                ],
+                "sample_of_uuid": [
+                    "c8c7e2ad-1cf4-49b2-b2a0-1cb033c63dbf",
+                    "f29b5a91-69f1-4921-8d8f-e62ce493c523",
+                    "5fbed112-60d9-4777-83ba-139fa170c05f",
+                    "819dc124-caa5-4fa1-bf99-e47a784b75f0",
+                    "45e124c5-edd3-492b-8f9b-580e7834c623",
+                    "073010c8-ac4d-44ee-a541-0bdaf68cb46c"
+                ],
+                "imaging_preparation_protocol": [
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "65dec4db-20e8-4505-83a7-6b73a43c64db",
+                        "version": 0,
+                        "model": {
+                            "type_name": "SpecimenImagingPreparationProtocol",
+                            "version": 3
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Specimen-2"
+                                }
+                            }
+                        ],
+                        "title": "Preparation and IF-staining of tumor tissue cryosections",
+                        "protocol_description": "The fresh-frozen tumor tissues of one ganglioneuroblastoma patient, one neuroblastoma patient and one Wilms tumor patient were embedded into tissue-tek-OCT and 4 \ud835\udf07\ud835\udc5a thick cryosections were prepared. Sections were mounted on Histobond glass slides (Marienfeld), fixed in 4.5% formaledhyde and stained with 4,6-diamino-2-phenylindole (DAPI), a blue fluorescent dye conventionally used for staining of nuclei for cellular imaging techniques. Finally, slides were covered with Vectashield and coverslips were sealed on the slides with rubber cement.",
+                        "signal_channel_information": []
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "fa9836ff-dfe2-4bb9-af81-ee450b028a30",
+                        "version": 0,
+                        "model": {
+                            "type_name": "SpecimenImagingPreparationProtocol",
+                            "version": 3
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Specimen-8"
+                                }
+                            }
+                        ],
+                        "title": "Preparation and IF-staining of HaCaT human skin keratinocyte cell line",
+                        "protocol_description": "The HaCaT cell line, a spontaneously transformed human epithelial cell line from adult skin, was cultivated either in culture flasks or on microscopy glass slides. Cell cultures were irradiated (2 and 6\u2009Gy), harvested, cytospinned, air-dried and IF stained. Cells grown and irradiated on the glass slides were directly subjected to IF staining. Cells were fixed in 4% formaldehyde for 10\u2009minutes at 4\u2009\u00b0C, and were permeabilized with 0.1% sodium dodecyl sulfate (SDS) in PBS for 6\u2009minutes. Slides were mounted with antifade solution Vectashield containing DAPI and coverslips were sealed on the slides with rubber cement.",
+                        "signal_channel_information": []
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "6b8fd66c-20bc-4cea-9bca-8411965dd7f4",
+                        "version": 0,
+                        "model": {
+                            "type_name": "SpecimenImagingPreparationProtocol",
+                            "version": 3
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Specimen-9"
+                                }
+                            }
+                        ],
+                        "title": "Preparation and IF-staining of tumor touch imprints and bone marrow cytospin preparations",
+                        "protocol_description": "Touch imprints were prepared from fresh primary tumors of 4 stage M neuroblastoma patients as previously described. Mononuclear cells were isolated from bone marrow aspirates of 3 stage M neuroblastoma patients by density gradient centrifugation and cytospinned as described. After fixation in 3.7% formaldehyde for 3\u2009minutes, cells were treated according to the Telomere PNA FISH Kit Cy3 protocol (Dako), mounted with Vectashield containing DAPI, covered and sealed.",
+                        "signal_channel_information": []
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "a4dad3fc-be06-467a-a52f-bb672e3c623f",
+                        "version": 0,
+                        "model": {
+                            "type_name": "SpecimenImagingPreparationProtocol",
+                            "version": 3
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Specimen-10"
+                                }
+                            }
+                        ],
+                        "title": "Preparation and IF-staining of neuroblastoma cell line cytospin preparations",
+                        "protocol_description": "STA-NB-10 and CLB-Ma are cell lines derived from neuroblastoma tumor tissue of patients with stage M disease. Preparation and drug-treatment were conducted as described. Briefly, cells were cultured in the absence or presence of 5\u2009nM topotecan, a chemotherapeutic drug for 3 weeks, detached and cytospinned to microscopy glass slides. Preparations were air-dried, fixed in 3.7% formaldehyde, immuno- and DAPI stained, covered and sealed.",
+                        "signal_channel_information": []
+                    }
+                ],
+                "sample_of": [
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "c8c7e2ad-1cf4-49b2-b2a0-1cb033c63dbf",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 4
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Biosample-1"
+                                }
+                            }
+                        ],
+                        "title": "Tumor sample from ganglioneuroblastoma patient",
+                        "organism_classification": [
+                            {
+                                "additional_metadata": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Schwann cell stroma-rich tissue from a patient with a ganglioneuroblastoma tumor",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "f29b5a91-69f1-4921-8d8f-e62ce493c523",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 4
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Biosample-2"
+                                }
+                            }
+                        ],
+                        "title": "Tumor sample from neuroblastoma patient",
+                        "organism_classification": [
+                            {
+                                "additional_metadata": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Tumor tissue from neuroblastoma patient",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "5fbed112-60d9-4777-83ba-139fa170c05f",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 4
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Biosample-4"
+                                }
+                            }
+                        ],
+                        "title": "Tumor sample from Wilms tumor patient",
+                        "organism_classification": [
+                            {
+                                "additional_metadata": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Wilms tumor tissue",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "819dc124-caa5-4fa1-bf99-e47a784b75f0",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 4
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Biosample-6"
+                                }
+                            }
+                        ],
+                        "title": "Skin keratinocyte cell line",
+                        "organism_classification": [
+                            {
+                                "additional_metadata": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "HaCaT cell line, a spontaneously transformed human epithelial cell line from adult skin",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "45e124c5-edd3-492b-8f9b-580e7834c623",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 4
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Biosample-3"
+                                }
+                            }
+                        ],
+                        "title": "Bone marrow sample from neuroblastoma patient",
+                        "organism_classification": [
+                            {
+                                "additional_metadata": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Bone marrow cells from neuroblastoma patient",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "073010c8-ac4d-44ee-a541-0bdaf68cb46c",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 4
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Biosample-5"
+                                }
+                            }
+                        ],
+                        "title": "Neuroblastoma cell lines",
+                        "organism_classification": [
+                            {
+                                "additional_metadata": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Patient-derived neuroblastoma cell lines (CLB-Ma, STA-NB10)",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    }
+                ]
+            },
+            "annotation_method": [],
+            "protocol": []
+        },
+        "representation": [
+            {
+                "object_creator": "bia_image_conversion",
+                "uuid": "bfa4a4d2-0873-4f45-b1c3-4125f82ea650",
+                "version": 0,
+                "model": {
+                    "type_name": "ImageRepresentation",
+                    "version": 4
+                },
+                "additional_metadata": [
+                    {
+                        "provenance": "bia_image_conversion",
+                        "name": "uuid_unique_input",
+                        "value": {
+                            "uuid_unique_input": "cbd6e9bd-4943-40a0-a0db-a13cffdcdc91 {'conversion_function': 'map_image_representation_to_2025_04_model'}"
+                        }
+                    }
+                ],
+                "image_format": ".ome.zarr",
+                "file_uri": [
+                    "https://uk1s3.embassy.ebi.ac.uk/bia-zarr-test/vizarr/index.html?source=https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD634/15e5f46d-369b-49cf-9fda-15c0d0ed67ab/15e5f46d-369b-49cf-9fda-15c0d0ed67ab.zarr/0"
+                ],
+                "total_size_in_bytes": 1430303,
+                "voxel_physical_size_x": 1.0,
+                "voxel_physical_size_y": 1.0,
+                "voxel_physical_size_z": 1.0,
+                "size_x": 1280,
+                "size_y": 1024,
+                "size_z": 1,
+                "size_c": 1,
+                "size_t": 1,
+                "image_viewer_setting": [],
+                "representation_of_uuid": "15e5f46d-369b-49cf-9fda-15c0d0ed67ab"
+            },
+            {
+                "object_creator": "bia_image_assignment",
+                "uuid": "cbd6e9bd-4943-40a0-a0db-a13cffdcdc91",
+                "version": 1,
+                "model": {
+                    "type_name": "ImageRepresentation",
+                    "version": 4
+                },
+                "additional_metadata": [
+                    {
+                        "provenance": "bia_image_conversion",
+                        "name": "file_pattern",
+                        "value": {
+                            "file_pattern": "dataset/rawimages/normal_20.tif"
+                        }
+                    },
+                    {
+                        "provenance": "bia_image_assignment",
+                        "name": "uuid_unique_input",
+                        "value": {
+                            "uuid_unique_input": "15e5f46d-369b-49cf-9fda-15c0d0ed67ab"
+                        }
+                    }
+                ],
+                "image_format": ".tiff",
+                "file_uri": [
+                    "https://www.ebi.ac.uk/biostudies/files/S-BIAD634/dataset/rawimages/normal_20.tif"
+                ],
+                "total_size_in_bytes": 1311278,
+                "voxel_physical_size_x": null,
+                "voxel_physical_size_y": null,
+                "voxel_physical_size_z": null,
+                "size_x": null,
+                "size_y": null,
+                "size_z": null,
+                "size_c": null,
+                "size_t": null,
+                "image_viewer_setting": [],
+                "representation_of_uuid": "15e5f46d-369b-49cf-9fda-15c0d0ed67ab"
+            }
+        ]
+    },
+    "906e2ace-8e99-4841-89e6-f95983632896": {
+        "object_creator": "bia_image_assignment",
+        "uuid": "906e2ace-8e99-4841-89e6-f95983632896",
+        "version": 1,
+        "model": {
+            "type_name": "Image",
+            "version": 2
+        },
+        "additional_metadata": [
+            {
+                "provenance": "bia_image_assignment",
+                "name": "attributes_from_file_reference_269b149b-f5b4-490f-876f-c1baa0b29ac0",
+                "value": {
+                    "attributes": {
+                        "file description": "Raw nuclear images in TIFF format",
+                        "Diagnosis": "normal (HaCaT)",
+                        "Preparation": "cellline cytospin",
+                        "Train-/Testset split": "train",
+                        "Testset class": "-",
+                        "Magnification": "63x",
+                        "Modality": "FM",
+                        "Device": "Zeiss Axioplan II",
+                        "Software": "Metafer",
+                        "Mean BG signal": "13,7",
+                        "Mean FG signal": "81,4",
+                        "Signal/Noise": "6",
+                        "S/N Class": ">=4,<40"
+                    }
+                }
+            },
+            {
+                "provenance": "bia_image_assignment",
+                "name": "file_pattern",
+                "value": {
+                    "file_pattern": "dataset/groundtruth/normal_20.tif"
+                }
+            },
+            {
+                "provenance": "bia_image_assignment",
+                "name": "uuid_unique_input",
+                "value": {
+                    "uuid_unique_input": "269b149b-f5b4-490f-876f-c1baa0b29ac0"
+                }
+            },
+            {
+                "provenance": "bia_image_assignment",
+                "name": "thumbnail_uri",
+                "value": {
+                    "thumbnail_uri": [
+                        "https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD634/31968bad-fb22-49f1-b782-dda04f9ee78a/56ea80c7-01ac-422c-9c22-c28de48c1e1b.png"
+                    ]
+                }
+            },
+            {
+                "provenance": "bia_image_assignment",
+                "name": "recommended_vizarr_representation",
+                "value": {
+                    "recommended_vizarr_representation": "7689ac81-1271-42c8-8ed3-a5a57590f82c"
+                }
+            }
+        ],
+        "label": null,
+        "submission_dataset_uuid": "b861c692-68f8-4c41-b583-162d4a44f793",
+        "creation_process_uuid": "5f19742f-20f9-439c-b0be-63df18c56b99",
+        "original_file_reference_uuid": [
+            "269b149b-f5b4-490f-876f-c1baa0b29ac0"
+        ],
+        "creation_process": {
+            "object_creator": "bia_image_assignment",
+            "uuid": "5f19742f-20f9-439c-b0be-63df18c56b99",
+            "version": 0,
+            "model": {
+                "type_name": "CreationProcess",
+                "version": 3
+            },
+            "additional_metadata": [
+                {
+                    "provenance": "bia_image_assignment",
+                    "name": "uuid_unique_input",
+                    "value": {
+                        "uuid_unique_input": "906e2ace-8e99-4841-89e6-f95983632896"
+                    }
+                }
+            ],
+            "subject_specimen_uuid": "1e85ed8b-8576-47ce-a267-3a63a13b349d",
+            "image_acquisition_protocol_uuid": [
+                "29f61c5f-ae01-438d-8aa0-d9a787751443"
+            ],
+            "input_image_uuid": ["15e5f46d-369b-49cf-9fda-15c0d0ed67ab"],
+            "protocol_uuid": [],
+            "annotation_method_uuid": [],
+            "acquisition_process": [
+                {
+                    "default_open": true,
+                    "object_creator": "bia_ingest",
+                    "uuid": "29f61c5f-ae01-438d-8aa0-d9a787751443",
+                    "version": 0,
+                    "model": {
+                        "type_name": "ImageAcquisitionProtocol",
+                        "version": 3
+                    },
+                    "additional_metadata": [
+                        {
+                            "provenance": "bia_ingest",
+                            "name": "uuid_unique_input",
+                            "value": {
+                                "uuid_unique_input": "Image acquisition-3"
+                            }
+                        }
+                    ],
+                    "title": "Fluorescence imaging",
+                    "protocol_description": "Samples were imaged using 1. an Axioplan-II microscope from Zeiss equipped with a Maerzhaeuser slide scanning stage and a Metasystems Coolcube 1 camera using the Metafer software system (V3.8.6) from Metasystems, 2. an Axioplan-II microscope from Zeiss equipped with a Zeiss AxioCam Mrm 1 using the Metasystems ISIS Software for microscopy image acquisition, 3. an LSM 780 microscope from Zeiss equipped with an Argonlaser 458\u2009nm, a photomultiplier tube (PMT) detector (371\u2013740\u2009nm) and a motorized Piezo Z-stage using the Zeiss Zen software package and 4. a SP8X from Leica equipped with a Diode Laser and a PMT detector (447\u2013468\u2009nm). For the presented dataset, we digitized the DAPI staining pattern representing nuclear DNA. Additional immunofluorescence or FISH stainings were in part available. An automatic illumination time was set as measured by pixel saturation (Metasystems Metafer and ISIS) or defined manually (Zeiss and Leica LSMs). Objectives used were a Zeiss Plan-Apochromat 10\u00d7 objective (Zeiss Axioplan II; numerical aperture 0.45; air), a Zeiss 20\u00d7 Plan-Apochromat (Zeiss LSM 780; numerical aperture 0.8; oil), a Zeiss 20\u00d7 Plan-Apochromat (Leica SP8X; nuermical aperture 0.75; oil), a Zeiss Plan-Neofluar 40\u00d7 objective (Zeiss Axioplan II; numerical aperture 0.75) and a Zeiss Plan-Apochromat 63\u00d7 objective (Zeiss Axioplan II, Zeiss LSM 780 and Leica SP8X; numerical aperture 1.4; oil). Representative field of views (FOVs) were selected according to the following quality criteria: sharpness, intact nuclei and a sufficient number of nuclei.",
+                    "imaging_instrument_description": "Axioplan-II microscope from Zeiss, LSM 780 microscope from Zeiss, SP8X from Leica",
+                    "fbbi_id": [],
+                    "imaging_method_name": [
+                        "fluorescence microscopy"
+                    ]
+                }
+            ],
+            "subject": {
+                "object_creator": "bia_image_assignment",
+                "uuid": "1e85ed8b-8576-47ce-a267-3a63a13b349d",
+                "version": 0,
+                "model": {
+                    "type_name": "Specimen",
+                    "version": 3
+                },
+                "additional_metadata": [
+                    {
+                        "provenance": "bia_image_assignment",
+                        "name": "uuid_unique_input",
+                        "value": {
+                            "uuid_unique_input": "906e2ace-8e99-4841-89e6-f95983632896"
+                        }
+                    }
+                ],
+                "imaging_preparation_protocol_uuid": [
+                    "65dec4db-20e8-4505-83a7-6b73a43c64db",
+                    "fa9836ff-dfe2-4bb9-af81-ee450b028a30",
+                    "6b8fd66c-20bc-4cea-9bca-8411965dd7f4",
+                    "a4dad3fc-be06-467a-a52f-bb672e3c623f"
+                ],
+                "sample_of_uuid": [
+                    "c8c7e2ad-1cf4-49b2-b2a0-1cb033c63dbf",
+                    "f29b5a91-69f1-4921-8d8f-e62ce493c523",
+                    "5fbed112-60d9-4777-83ba-139fa170c05f",
+                    "819dc124-caa5-4fa1-bf99-e47a784b75f0",
+                    "45e124c5-edd3-492b-8f9b-580e7834c623",
+                    "073010c8-ac4d-44ee-a541-0bdaf68cb46c"
+                ],
+                "imaging_preparation_protocol": [
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "65dec4db-20e8-4505-83a7-6b73a43c64db",
+                        "version": 0,
+                        "model": {
+                            "type_name": "SpecimenImagingPreparationProtocol",
+                            "version": 3
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Specimen-2"
+                                }
+                            }
+                        ],
+                        "title": "Preparation and IF-staining of tumor tissue cryosections",
+                        "protocol_description": "The fresh-frozen tumor tissues of one ganglioneuroblastoma patient, one neuroblastoma patient and one Wilms tumor patient were embedded into tissue-tek-OCT and 4 \ud835\udf07\ud835\udc5a thick cryosections were prepared. Sections were mounted on Histobond glass slides (Marienfeld), fixed in 4.5% formaledhyde and stained with 4,6-diamino-2-phenylindole (DAPI), a blue fluorescent dye conventionally used for staining of nuclei for cellular imaging techniques. Finally, slides were covered with Vectashield and coverslips were sealed on the slides with rubber cement.",
+                        "signal_channel_information": []
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "fa9836ff-dfe2-4bb9-af81-ee450b028a30",
+                        "version": 0,
+                        "model": {
+                            "type_name": "SpecimenImagingPreparationProtocol",
+                            "version": 3
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Specimen-8"
+                                }
+                            }
+                        ],
+                        "title": "Preparation and IF-staining of HaCaT human skin keratinocyte cell line",
+                        "protocol_description": "The HaCaT cell line, a spontaneously transformed human epithelial cell line from adult skin, was cultivated either in culture flasks or on microscopy glass slides. Cell cultures were irradiated (2 and 6\u2009Gy), harvested, cytospinned, air-dried and IF stained. Cells grown and irradiated on the glass slides were directly subjected to IF staining. Cells were fixed in 4% formaldehyde for 10\u2009minutes at 4\u2009\u00b0C, and were permeabilized with 0.1% sodium dodecyl sulfate (SDS) in PBS for 6\u2009minutes. Slides were mounted with antifade solution Vectashield containing DAPI and coverslips were sealed on the slides with rubber cement.",
+                        "signal_channel_information": []
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "6b8fd66c-20bc-4cea-9bca-8411965dd7f4",
+                        "version": 0,
+                        "model": {
+                            "type_name": "SpecimenImagingPreparationProtocol",
+                            "version": 3
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Specimen-9"
+                                }
+                            }
+                        ],
+                        "title": "Preparation and IF-staining of tumor touch imprints and bone marrow cytospin preparations",
+                        "protocol_description": "Touch imprints were prepared from fresh primary tumors of 4 stage M neuroblastoma patients as previously described. Mononuclear cells were isolated from bone marrow aspirates of 3 stage M neuroblastoma patients by density gradient centrifugation and cytospinned as described. After fixation in 3.7% formaldehyde for 3\u2009minutes, cells were treated according to the Telomere PNA FISH Kit Cy3 protocol (Dako), mounted with Vectashield containing DAPI, covered and sealed.",
+                        "signal_channel_information": []
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "a4dad3fc-be06-467a-a52f-bb672e3c623f",
+                        "version": 0,
+                        "model": {
+                            "type_name": "SpecimenImagingPreparationProtocol",
+                            "version": 3
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Specimen-10"
+                                }
+                            }
+                        ],
+                        "title": "Preparation and IF-staining of neuroblastoma cell line cytospin preparations",
+                        "protocol_description": "STA-NB-10 and CLB-Ma are cell lines derived from neuroblastoma tumor tissue of patients with stage M disease. Preparation and drug-treatment were conducted as described. Briefly, cells were cultured in the absence or presence of 5\u2009nM topotecan, a chemotherapeutic drug for 3 weeks, detached and cytospinned to microscopy glass slides. Preparations were air-dried, fixed in 3.7% formaldehyde, immuno- and DAPI stained, covered and sealed.",
+                        "signal_channel_information": []
+                    }
+                ],
+                "sample_of": [
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "c8c7e2ad-1cf4-49b2-b2a0-1cb033c63dbf",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 4
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Biosample-1"
+                                }
+                            }
+                        ],
+                        "title": "Tumor sample from ganglioneuroblastoma patient",
+                        "organism_classification": [
+                            {
+                                "additional_metadata": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Schwann cell stroma-rich tissue from a patient with a ganglioneuroblastoma tumor",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "f29b5a91-69f1-4921-8d8f-e62ce493c523",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 4
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Biosample-2"
+                                }
+                            }
+                        ],
+                        "title": "Tumor sample from neuroblastoma patient",
+                        "organism_classification": [
+                            {
+                                "additional_metadata": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Tumor tissue from neuroblastoma patient",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "5fbed112-60d9-4777-83ba-139fa170c05f",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 4
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Biosample-4"
+                                }
+                            }
+                        ],
+                        "title": "Tumor sample from Wilms tumor patient",
+                        "organism_classification": [
+                            {
+                                "additional_metadata": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Wilms tumor tissue",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "819dc124-caa5-4fa1-bf99-e47a784b75f0",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 4
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Biosample-6"
+                                }
+                            }
+                        ],
+                        "title": "Skin keratinocyte cell line",
+                        "organism_classification": [
+                            {
+                                "additional_metadata": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "HaCaT cell line, a spontaneously transformed human epithelial cell line from adult skin",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "45e124c5-edd3-492b-8f9b-580e7834c623",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 4
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Biosample-3"
+                                }
+                            }
+                        ],
+                        "title": "Bone marrow sample from neuroblastoma patient",
+                        "organism_classification": [
+                            {
+                                "additional_metadata": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Bone marrow cells from neuroblastoma patient",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "073010c8-ac4d-44ee-a541-0bdaf68cb46c",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 4
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Biosample-5"
+                                }
+                            }
+                        ],
+                        "title": "Neuroblastoma cell lines",
+                        "organism_classification": [
+                            {
+                                "additional_metadata": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Patient-derived neuroblastoma cell lines (CLB-Ma, STA-NB10)",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    }
+                ]
+            },
+            "annotation_method": [],
+            "protocol": []
+        },
+        "representation": [
+            {
+                "object_creator": "bia_image_assignment",
+                "uuid": "6cd0f536-f8a7-4b50-bef1-ee839c8527df",
+                "version": 1,
+                "model": {
+                    "type_name": "ImageRepresentation",
+                    "version": 4
+                },
+                "additional_metadata": [
+                    {
+                        "provenance": "bia_image_conversion",
+                        "name": "file_pattern",
+                        "value": {
+                            "file_pattern": "dataset/groundtruth/normal_20.tif"
+                        }
+                    },
+                    {
+                        "provenance": "bia_image_assignment",
+                        "name": "uuid_unique_input",
+                        "value": {
+                            "uuid_unique_input": "906e2ace-8e99-4841-89e6-f95983632896"
+                        }
+                    }
+                ],
+                "image_format": ".tiff",
+                "file_uri": [
+                    "https://www.ebi.ac.uk/biostudies/files/S-BIAD634/dataset/groundtruth/normal_20.tif"
+                ],
+                "total_size_in_bytes": 1311278,
+                "voxel_physical_size_x": null,
+                "voxel_physical_size_y": null,
+                "voxel_physical_size_z": null,
+                "size_x": null,
+                "size_y": null,
+                "size_z": null,
+                "size_c": null,
+                "size_t": null,
+                "image_viewer_setting": [],
+                "representation_of_uuid": "906e2ace-8e99-4841-89e6-f95983632896"
+            },
+            {
+                "object_creator": "bia_image_conversion",
+                "uuid": "7689ac81-1271-42c8-8ed3-a5a57590f82c",
+                "version": 0,
+                "model": {
+                    "type_name": "ImageRepresentation",
+                    "version": 4
+                },
+                "additional_metadata": [
+                    {
+                        "provenance": "bia_image_conversion",
+                        "name": "attributes_from_bioformat2raw_conversion",
+                        "value": {
+                            "BigEndian": "true",
+                            "DimensionOrder": "XYZCT",
+                            "ID": "Pixels:0",
+                            "Interleaved": "false",
+                            "SignificantBits": "8",
+                            "Type": "uint8",
+                            "{http://www.openmicroscopy.org/Schemas/OME/2016-06}Channel": {
+                                "ID": "Channel:0:0",
+                                "SamplesPerPixel": "1",
+                                "{http://www.openmicroscopy.org/Schemas/OME/2016-06}LightPath": null
+                            },
+                            "{http://www.openmicroscopy.org/Schemas/OME/2016-06}MetadataOnly": null
+                        }
+                    },
+                    {
+                        "provenance": "bia_image_conversion",
+                        "name": "uuid_unique_input",
+                        "value": {
+                            "uuid_unique_input": "6cd0f536-f8a7-4b50-bef1-ee839c8527df {'conversion_function': 'map_image_representation_to_2025_04_model'}"
+                        }
+                    }
+                ],
+                "image_format": ".ome.zarr",
+                "file_uri": [
+                    "https://uk1s3.embassy.ebi.ac.uk/bia-zarr-test/vizarr/index.html?source=https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD634/906e2ace-8e99-4841-89e6-f95983632896/906e2ace-8e99-4841-89e6-f95983632896.zarr/0"
+                ],
+                "total_size_in_bytes": 0,
+                "voxel_physical_size_x": null,
+                "voxel_physical_size_y": null,
+                "voxel_physical_size_z": null,
+                "size_x": 1280,
+                "size_y": 1024,
+                "size_z": 1,
+                "size_c": 1,
+                "size_t": 1,
+                "image_viewer_setting": [],
+                "representation_of_uuid": "906e2ace-8e99-4841-89e6-f95983632896"
+            }
+        ]
+    },
+    "906e2ace-8e99-4841-89e6-f95983632869": {
+        "object_creator": "bia_image_assignment",
+        "uuid": "906e2ace-8e99-4841-89e6-f95983632869",
+        "version": 1,
+        "model": {
+            "type_name": "Image",
+            "version": 2
+        },
+        "additional_metadata": [
+            {
+                "provenance": "bia_image_assignment",
+                "name": "attributes_from_file_reference_269b149b-f5b4-490f-876f-c1baa0b29ac0",
+                "value": {
+                    "attributes": {
+                        "file description": "Test",
+                        "Diagnosis": "test",
+                        "Preparation": "test",
+                        "Train-/Testset split": "train",
+                        "Testset class": "test",
+                        "Magnification": "test",
+                        "Modality": "test",
+                        "Device": "test",
+                        "Software": "test",
+                        "Mean BG signal": "13,7",
+                        "Mean FG signal": "81,4",
+                        "Signal/Noise": "6",
+                        "S/N Class": ">=4,<40"
+                    }
+                }
+            },
+            {
+                "provenance": "bia_image_assignment",
+                "name": "file_pattern",
+                "value": {
+                    "file_pattern": "dataset/groundtruth/normal_25.tif"
+                }
+            },
+            {
+                "provenance": "bia_image_assignment",
+                "name": "uuid_unique_input",
+                "value": {
+                    "uuid_unique_input": "269b149b-f5b4-490f-876f-c1baa0b29ac0"
+                }
+            },
+            {
+                "provenance": "bia_image_assignment",
+                "name": "thumbnail_uri",
+                "value": {
+                    "thumbnail_uri": [
+                        "https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD634/31968bad-fb22-49f1-b782-dda04f9ee78a/56ea80c7-01ac-422c-9c22-c28de48c1e1b.png"
+                    ]
+                }
+            },
+            {
+                "provenance": "bia_image_assignment",
+                "name": "recommended_vizarr_representation",
+                "value": {
+                    "recommended_vizarr_representation": "7689ac81-1271-42c8-8ed3-a5a57590f82c"
+                }
+            }
+        ],
+        "label": null,
+        "submission_dataset_uuid": "b861c692-68f8-4c41-b583-162d4a44f793",
+        "creation_process_uuid": "5f19742f-20f9-439c-b0be-63df18c56b99",
+        "original_file_reference_uuid": [
+            "269b149b-f5b4-490f-876f-c1baa0b29ac0"
+        ],
+        "creation_process": {
+            "object_creator": "bia_image_assignment",
+            "uuid": "5f19742f-20f9-439c-b0be-63df18c56b99",
+            "version": 0,
+            "model": {
+                "type_name": "CreationProcess",
+                "version": 3
+            },
+            "additional_metadata": [
+                {
+                    "provenance": "bia_image_assignment",
+                    "name": "uuid_unique_input",
+                    "value": {
+                        "uuid_unique_input": "906e2ace-8e99-4841-89e6-f95983632869"
+                    }
+                }
+            ],
+            "subject_specimen_uuid": "1e85ed8b-8576-47ce-a267-3a63a13b349d",
+            "image_acquisition_protocol_uuid": [
+                "29f61c5f-ae01-438d-8aa0-d9a787751443"
+            ],
+            "input_image_uuid": ["15e5f46d-369b-49cf-9fda-15c0d0ed67ab"],
+            "protocol_uuid": [],
+            "annotation_method_uuid": [],
+            "acquisition_process": [
+                {
+                    "default_open": true,
+                    "object_creator": "bia_ingest",
+                    "uuid": "29f61c5f-ae01-438d-8aa0-d9a787751443",
+                    "version": 0,
+                    "model": {
+                        "type_name": "ImageAcquisitionProtocol",
+                        "version": 3
+                    },
+                    "additional_metadata": [
+                        {
+                            "provenance": "bia_ingest",
+                            "name": "uuid_unique_input",
+                            "value": {
+                                "uuid_unique_input": "Image acquisition-3"
+                            }
+                        }
+                    ],
+                    "title": "Fluorescence imaging",
+                    "protocol_description": "Samples were imaged using 1. an Axioplan-II microscope from Zeiss equipped with a Maerzhaeuser slide scanning stage and a Metasystems Coolcube 1 camera using the Metafer software system (V3.8.6) from Metasystems, 2. an Axioplan-II microscope from Zeiss equipped with a Zeiss AxioCam Mrm 1 using the Metasystems ISIS Software for microscopy image acquisition, 3. an LSM 780 microscope from Zeiss equipped with an Argonlaser 458\u2009nm, a photomultiplier tube (PMT) detector (371\u2013740\u2009nm) and a motorized Piezo Z-stage using the Zeiss Zen software package and 4. a SP8X from Leica equipped with a Diode Laser and a PMT detector (447\u2013468\u2009nm). For the presented dataset, we digitized the DAPI staining pattern representing nuclear DNA. Additional immunofluorescence or FISH stainings were in part available. An automatic illumination time was set as measured by pixel saturation (Metasystems Metafer and ISIS) or defined manually (Zeiss and Leica LSMs). Objectives used were a Zeiss Plan-Apochromat 10\u00d7 objective (Zeiss Axioplan II; numerical aperture 0.45; air), a Zeiss 20\u00d7 Plan-Apochromat (Zeiss LSM 780; numerical aperture 0.8; oil), a Zeiss 20\u00d7 Plan-Apochromat (Leica SP8X; nuermical aperture 0.75; oil), a Zeiss Plan-Neofluar 40\u00d7 objective (Zeiss Axioplan II; numerical aperture 0.75) and a Zeiss Plan-Apochromat 63\u00d7 objective (Zeiss Axioplan II, Zeiss LSM 780 and Leica SP8X; numerical aperture 1.4; oil). Representative field of views (FOVs) were selected according to the following quality criteria: sharpness, intact nuclei and a sufficient number of nuclei.",
+                    "imaging_instrument_description": "Axioplan-II microscope from Zeiss, LSM 780 microscope from Zeiss, SP8X from Leica",
+                    "fbbi_id": [],
+                    "imaging_method_name": [
+                        "fluorescence microscopy"
+                    ]
+                }
+            ],
+            "subject": {
+                "object_creator": "bia_image_assignment",
+                "uuid": "1e85ed8b-8576-47ce-a267-3a63a13b349d",
+                "version": 0,
+                "model": {
+                    "type_name": "Specimen",
+                    "version": 3
+                },
+                "additional_metadata": [
+                    {
+                        "provenance": "bia_image_assignment",
+                        "name": "uuid_unique_input",
+                        "value": {
+                            "uuid_unique_input": "906e2ace-8e99-4841-89e6-f95983632869"
+                        }
+                    }
+                ],
+                "imaging_preparation_protocol_uuid": [
+                    "65dec4db-20e8-4505-83a7-6b73a43c64db",
+                    "fa9836ff-dfe2-4bb9-af81-ee450b028a30",
+                    "6b8fd66c-20bc-4cea-9bca-8411965dd7f4",
+                    "a4dad3fc-be06-467a-a52f-bb672e3c623f"
+                ],
+                "sample_of_uuid": [
+                    "c8c7e2ad-1cf4-49b2-b2a0-1cb033c63dbf",
+                    "f29b5a91-69f1-4921-8d8f-e62ce493c523",
+                    "5fbed112-60d9-4777-83ba-139fa170c05f",
+                    "819dc124-caa5-4fa1-bf99-e47a784b75f0",
+                    "45e124c5-edd3-492b-8f9b-580e7834c623",
+                    "073010c8-ac4d-44ee-a541-0bdaf68cb46c"
+                ],
+                "imaging_preparation_protocol": [
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "65dec4db-20e8-4505-83a7-6b73a43c64db",
+                        "version": 0,
+                        "model": {
+                            "type_name": "SpecimenImagingPreparationProtocol",
+                            "version": 3
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Specimen-2"
+                                }
+                            }
+                        ],
+                        "title": "Preparation and IF-staining of tumor tissue cryosections",
+                        "protocol_description": "The fresh-frozen tumor tissues of one ganglioneuroblastoma patient, one neuroblastoma patient and one Wilms tumor patient were embedded into tissue-tek-OCT and 4 \ud835\udf07\ud835\udc5a thick cryosections were prepared. Sections were mounted on Histobond glass slides (Marienfeld), fixed in 4.5% formaledhyde and stained with 4,6-diamino-2-phenylindole (DAPI), a blue fluorescent dye conventionally used for staining of nuclei for cellular imaging techniques. Finally, slides were covered with Vectashield and coverslips were sealed on the slides with rubber cement.",
+                        "signal_channel_information": []
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "fa9836ff-dfe2-4bb9-af81-ee450b028a30",
+                        "version": 0,
+                        "model": {
+                            "type_name": "SpecimenImagingPreparationProtocol",
+                            "version": 3
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Specimen-8"
+                                }
+                            }
+                        ],
+                        "title": "Preparation and IF-staining of HaCaT human skin keratinocyte cell line",
+                        "protocol_description": "The HaCaT cell line, a spontaneously transformed human epithelial cell line from adult skin, was cultivated either in culture flasks or on microscopy glass slides. Cell cultures were irradiated (2 and 6\u2009Gy), harvested, cytospinned, air-dried and IF stained. Cells grown and irradiated on the glass slides were directly subjected to IF staining. Cells were fixed in 4% formaldehyde for 10\u2009minutes at 4\u2009\u00b0C, and were permeabilized with 0.1% sodium dodecyl sulfate (SDS) in PBS for 6\u2009minutes. Slides were mounted with antifade solution Vectashield containing DAPI and coverslips were sealed on the slides with rubber cement.",
+                        "signal_channel_information": []
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "6b8fd66c-20bc-4cea-9bca-8411965dd7f4",
+                        "version": 0,
+                        "model": {
+                            "type_name": "SpecimenImagingPreparationProtocol",
+                            "version": 3
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Specimen-9"
+                                }
+                            }
+                        ],
+                        "title": "Preparation and IF-staining of tumor touch imprints and bone marrow cytospin preparations",
+                        "protocol_description": "Touch imprints were prepared from fresh primary tumors of 4 stage M neuroblastoma patients as previously described. Mononuclear cells were isolated from bone marrow aspirates of 3 stage M neuroblastoma patients by density gradient centrifugation and cytospinned as described. After fixation in 3.7% formaldehyde for 3\u2009minutes, cells were treated according to the Telomere PNA FISH Kit Cy3 protocol (Dako), mounted with Vectashield containing DAPI, covered and sealed.",
+                        "signal_channel_information": []
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "a4dad3fc-be06-467a-a52f-bb672e3c623f",
+                        "version": 0,
+                        "model": {
+                            "type_name": "SpecimenImagingPreparationProtocol",
+                            "version": 3
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Specimen-10"
+                                }
+                            }
+                        ],
+                        "title": "Preparation and IF-staining of neuroblastoma cell line cytospin preparations",
+                        "protocol_description": "STA-NB-10 and CLB-Ma are cell lines derived from neuroblastoma tumor tissue of patients with stage M disease. Preparation and drug-treatment were conducted as described. Briefly, cells were cultured in the absence or presence of 5\u2009nM topotecan, a chemotherapeutic drug for 3 weeks, detached and cytospinned to microscopy glass slides. Preparations were air-dried, fixed in 3.7% formaldehyde, immuno- and DAPI stained, covered and sealed.",
+                        "signal_channel_information": []
+                    }
+                ],
+                "sample_of": [
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "c8c7e2ad-1cf4-49b2-b2a0-1cb033c63dbf",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 4
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Biosample-1"
+                                }
+                            }
+                        ],
+                        "title": "Tumor sample from ganglioneuroblastoma patient",
+                        "organism_classification": [
+                            {
+                                "additional_metadata": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Schwann cell stroma-rich tissue from a patient with a ganglioneuroblastoma tumor",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "f29b5a91-69f1-4921-8d8f-e62ce493c523",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 4
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Biosample-2"
+                                }
+                            }
+                        ],
+                        "title": "Tumor sample from neuroblastoma patient",
+                        "organism_classification": [
+                            {
+                                "additional_metadata": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Tumor tissue from neuroblastoma patient",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "5fbed112-60d9-4777-83ba-139fa170c05f",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 4
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Biosample-4"
+                                }
+                            }
+                        ],
+                        "title": "Tumor sample from Wilms tumor patient",
+                        "organism_classification": [
+                            {
+                                "additional_metadata": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Wilms tumor tissue",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "819dc124-caa5-4fa1-bf99-e47a784b75f0",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 4
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Biosample-6"
+                                }
+                            }
+                        ],
+                        "title": "Skin keratinocyte cell line",
+                        "organism_classification": [
+                            {
+                                "additional_metadata": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "HaCaT cell line, a spontaneously transformed human epithelial cell line from adult skin",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "45e124c5-edd3-492b-8f9b-580e7834c623",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 4
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Biosample-3"
+                                }
+                            }
+                        ],
+                        "title": "Bone marrow sample from neuroblastoma patient",
+                        "organism_classification": [
+                            {
+                                "additional_metadata": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Bone marrow cells from neuroblastoma patient",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "073010c8-ac4d-44ee-a541-0bdaf68cb46c",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 4
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Biosample-5"
+                                }
+                            }
+                        ],
+                        "title": "Neuroblastoma cell lines",
+                        "organism_classification": [
+                            {
+                                "additional_metadata": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Patient-derived neuroblastoma cell lines (CLB-Ma, STA-NB10)",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    }
+                ]
+            },
+            "annotation_method": [],
+            "protocol": []
+        },
+        "representation": [
+            {
+                "object_creator": "bia_image_assignment",
+                "uuid": "6cd0f536-f8a7-4b50-bef1-ee839c8527df",
+                "version": 1,
+                "model": {
+                    "type_name": "ImageRepresentation",
+                    "version": 4
+                },
+                "additional_metadata": [
+                    {
+                        "provenance": "bia_image_conversion",
+                        "name": "file_pattern",
+                        "value": {
+                            "file_pattern": "dataset/groundtruth/normal_25.tif"
+                        }
+                    },
+                    {
+                        "provenance": "bia_image_assignment",
+                        "name": "uuid_unique_input",
+                        "value": {
+                            "uuid_unique_input": "906e2ace-8e99-4841-89e6-f95983632869"
+                        }
+                    }
+                ],
+                "image_format": ".tiff",
+                "file_uri": [
+                    "https://www.ebi.ac.uk/biostudies/files/S-BIAD634/dataset/groundtruth/normal_25.tif"
+                ],
+                "total_size_in_bytes": 1311278,
+                "voxel_physical_size_x": null,
+                "voxel_physical_size_y": null,
+                "voxel_physical_size_z": null,
+                "size_x": null,
+                "size_y": null,
+                "size_z": null,
+                "size_c": null,
+                "size_t": null,
+                "image_viewer_setting": [],
+                "representation_of_uuid": "906e2ace-8e99-4841-89e6-f95983632869"
+            },
+            {
+                "object_creator": "bia_image_conversion",
+                "uuid": "7689ac81-1271-42c8-8ed3-a5a57590f82c",
+                "version": 0,
+                "model": {
+                    "type_name": "ImageRepresentation",
+                    "version": 4
+                },
+                "additional_metadata": [
+                    {
+                        "provenance": "bia_image_conversion",
+                        "name": "attributes_from_bioformat2raw_conversion",
+                        "value": {
+                            "BigEndian": "true",
+                            "DimensionOrder": "XYZCT",
+                            "ID": "Pixels:0",
+                            "Interleaved": "false",
+                            "SignificantBits": "8",
+                            "Type": "uint8",
+                            "{http://www.openmicroscopy.org/Schemas/OME/2016-06}Channel": {
+                                "ID": "Channel:0:0",
+                                "SamplesPerPixel": "1",
+                                "{http://www.openmicroscopy.org/Schemas/OME/2016-06}LightPath": null
+                            },
+                            "{http://www.openmicroscopy.org/Schemas/OME/2016-06}MetadataOnly": null
+                        }
+                    },
+                    {
+                        "provenance": "bia_image_conversion",
+                        "name": "uuid_unique_input",
+                        "value": {
+                            "uuid_unique_input": "6cd0f536-f8a7-4b50-bef1-ee839c8527df {'conversion_function': 'map_image_representation_to_2025_04_model'}"
+                        }
+                    }
+                ],
+                "image_format": ".ome.zarr",
+                "file_uri": [
+                    "https://uk1s3.embassy.ebi.ac.uk/bia-zarr-test/vizarr/index.html?source=https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD634/00fefce9-850f-43eb-b165-e4fa3aef8e94/00fefce9-850f-43eb-b165-e4fa3aef8e94.zarr/0"
+                ],
+                "total_size_in_bytes": 0,
+                "voxel_physical_size_x": null,
+                "voxel_physical_size_y": null,
+                "voxel_physical_size_z": null,
+                "size_x": 1280,
+                "size_y": 1024,
+                "size_z": 1,
+                "size_c": 1,
+                "size_t": 1,
+                "image_viewer_setting": [],
+                "representation_of_uuid": "906e2ace-8e99-4841-89e6-f95983632869"
+            }
+        ]
+    }
+}

--- a/src/data/current-export-mock/bia-ai-study-export.json
+++ b/src/data/current-export-mock/bia-ai-study-export.json
@@ -1,0 +1,1219 @@
+{
+    "S-BIAD634": {
+        "object_creator": "bia_ingest",
+        "uuid": "0ea2dc40-bf51-4ff8-82e9-2e4cbd8efd71",
+        "version": 0,
+        "model": {
+            "type_name": "Study",
+            "version": 3
+        },
+        "additional_metadata": [
+            {
+                "provenance": "bia_ingest",
+                "name": "biostudies json/pagetab entry",
+                "value": {
+                    "json": "https://www.ebi.ac.uk/biostudies/files/S-BIAD634/S-BIAD634.json",
+                    "pagetab": "https://www.ebi.ac.uk/biostudies/files/S-BIAD634/S-BIAD634.tsv"
+                }
+            }
+        ],
+        "accession_id": "S-BIAD634",
+        "licence": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "author": [
+            {
+                "rorid": null,
+                "address": null,
+                "website": null,
+                "orcid": "0000-0002-1439-5301",
+                "display_name": "Sabine Taschner-Mandl",
+                "affiliation": [
+                    {
+                        "rorid": null,
+                        "address": null,
+                        "website": null,
+                        "display_name": "Children's Cancer Research Institute"
+                    }
+                ],
+                "contact_email": "sabine.taschner@ccri.at",
+                "role": [
+                    "conceptualization",
+                    "data acquisition"
+                ]
+            },
+            {
+                "rorid": null,
+                "address": null,
+                "website": null,
+                "orcid": null,
+                "display_name": "Inge M. Ambros",
+                "affiliation": [
+                    {
+                        "rorid": null,
+                        "address": null,
+                        "website": null,
+                        "display_name": "Children's Cancer Research Institute"
+                    }
+                ],
+                "contact_email": "inge.ambros@ccri.at",
+                "role": [
+                    "data acquisition",
+                    "data annotation"
+                ]
+            },
+            {
+                "rorid": null,
+                "address": null,
+                "website": null,
+                "orcid": "0000-0002-5507-7211",
+                "display_name": "Peter F. Ambros",
+                "affiliation": [
+                    {
+                        "rorid": null,
+                        "address": null,
+                        "website": null,
+                        "display_name": "Children's Cancer Research Institute"
+                    }
+                ],
+                "contact_email": "peter.ambros@ccri.at",
+                "role": [
+                    "conceptualization",
+                    "data acquisition"
+                ]
+            },
+            {
+                "rorid": null,
+                "address": null,
+                "website": null,
+                "orcid": null,
+                "display_name": "Klaus Beiske",
+                "affiliation": [
+                    {
+                        "rorid": null,
+                        "address": null,
+                        "website": null,
+                        "display_name": "Oslo University Hospital"
+                    }
+                ],
+                "contact_email": "klaus.beiske@medisin.uio.no",
+                "role": [
+                    "data annotation"
+                ]
+            },
+            {
+                "rorid": null,
+                "address": null,
+                "website": null,
+                "orcid": "0000-0002-7149-5843",
+                "display_name": "Allan  Hanbury",
+                "affiliation": [
+                    {
+                        "rorid": null,
+                        "address": null,
+                        "website": null,
+                        "display_name": "TU Wien"
+                    }
+                ],
+                "contact_email": "hanbury@ifs.tuwien.ac.at",
+                "role": [
+                    "conceptualization"
+                ]
+            },
+            {
+                "rorid": null,
+                "address": null,
+                "website": null,
+                "orcid": "0000-0003-1477-6849",
+                "display_name": "Wolfgang Doerr",
+                "affiliation": [
+                    {
+                        "rorid": null,
+                        "address": null,
+                        "website": null,
+                        "display_name": "TRAB-Applied and Translational Radiobiology, Department of Radiation Oncology, Medical University of Vienna"
+                    }
+                ],
+                "contact_email": "wolfgang.doerr@meduniwien.ac.at",
+                "role": [
+                    "resources"
+                ]
+            },
+            {
+                "rorid": null,
+                "address": null,
+                "website": null,
+                "orcid": "0000-0001-7046-3412",
+                "display_name": "Tamara Weiss",
+                "affiliation": [
+                    {
+                        "rorid": null,
+                        "address": null,
+                        "website": null,
+                        "display_name": "Children's Cancer Research Institute"
+                    }
+                ],
+                "contact_email": "tamara.weiss@meduniwien.ac.at",
+                "role": [
+                    "data acquisition",
+                    "data annotation"
+                ]
+            },
+            {
+                "rorid": null,
+                "address": null,
+                "website": null,
+                "orcid": null,
+                "display_name": "Maria Berneder",
+                "affiliation": [
+                    {
+                        "rorid": null,
+                        "address": null,
+                        "website": null,
+                        "display_name": "Children's Cancer Research Institute"
+                    }
+                ],
+                "contact_email": "maria.berneder@ccri.at",
+                "role": [
+                    "sample preparation"
+                ]
+            },
+            {
+                "rorid": null,
+                "address": null,
+                "website": null,
+                "orcid": null,
+                "display_name": "Magdalena Ambros",
+                "affiliation": [
+                    {
+                        "rorid": null,
+                        "address": null,
+                        "website": null,
+                        "display_name": "Children's Cancer Research Institute"
+                    }
+                ],
+                "contact_email": "magdalena.ambros@ccri.at",
+                "role": [
+                    "data acquisition"
+                ]
+            },
+            {
+                "rorid": null,
+                "address": null,
+                "website": null,
+                "orcid": null,
+                "display_name": "Eva Bozsaky",
+                "affiliation": [
+                    {
+                        "rorid": null,
+                        "address": null,
+                        "website": null,
+                        "display_name": "Children's Cancer Research Institute"
+                    }
+                ],
+                "contact_email": "eva.bozsaky@ccri.at",
+                "role": [
+                    "data acquisition",
+                    "data annotation"
+                ]
+            },
+            {
+                "rorid": null,
+                "address": null,
+                "website": null,
+                "orcid": "0000-0003-4557-5652",
+                "display_name": "Florian Kromp",
+                "affiliation": [
+                    {
+                        "rorid": null,
+                        "address": null,
+                        "website": null,
+                        "display_name": "Children's Cancer Research Institute"
+                    }
+                ],
+                "contact_email": "florian.kromp@ccri.at",
+                "role": [
+                    "conceptualization",
+                    "data acquisition",
+                    "data annotation",
+                    "data analysis"
+                ]
+            },
+            {
+                "rorid": null,
+                "address": null,
+                "website": null,
+                "orcid": "0000-0002-0456-6912",
+                "display_name": "Teresa Zulueta-Coarasa",
+                "affiliation": [
+                    {
+                        "rorid": null,
+                        "address": null,
+                        "website": null,
+                        "display_name": "European Bioinformatics Institute (EMBL-EBI)"
+                    }
+                ],
+                "contact_email": "teresaz@ebi.ac.uk",
+                "role": [
+                    "data curation"
+                ]
+            }
+        ],
+        "title": "An annotated fluorescence image dataset for training nuclear segmentation methods",
+        "release_date": "2023-03-07",
+        "description": "This dataset contains annotated fluorescent nuclear images of normal or cancer cells from different tissue origins and sample preparation types, and can be used to train machine-learning based nuclear image segmentation algorithms. It consists of 79 expert-annotated fluorescence images of immuno and DAPI stained samples containing 7813 nuclei in total. In addition, the dataset is heterogenous in aspects such as type of preparation, imaging modality, magnification, signal-to-noise ratio and other technical aspects. Relevant parameters, e.g. diagnosis, magnification, signal-to-noise ratio and modality with respect to the type of preparation are provided in the file list. The images are derived from one Schwann cell stroma-rich tissue (from a ganglioneuroblastoma) cryosection (10 images/2773 nuclei), seven neuroblastoma (NB) patients (19 images/931 nuclei), one Wilms patient (1 image/102 nuclei), two NB cell lines (CLB-Ma, STA-NB10) (8 images/1785 nuclei) and a human keratinocyte cell line (HaCaT) (41 images/2222 nuclei).",
+        "keyword": [
+            "AI",
+            "segmentation",
+            "nucleus",
+            "fluorescence"
+        ],
+        "acknowledgement": "",
+        "see_also": [],
+        "related_publication": [],
+        "grant": [],
+        "funding_statement": "This work was facilitated by an EraSME grant (project TisQuant) under the grant no. 844198 and by a COIN grant (project VISIOMICS) under the grant no. 861750, both grants kindly provided by the Austrian Research Promotion Agency (FFG), and the St. Anna Kinderkrebsforschung. Partial funding was further provided by BMK, BMDW, and the Province of Upper Austria in the frame of the COMET Programme managed by FFG.",
+        "dataset": [
+            {
+                "image_count": 6,
+                "file_reference_count": 80,
+                "file_reference_size_bytes": 95929564,
+                "file_type_counts": {
+                    "file": 80
+                },
+                "object_creator": "bia_ingest",
+                "uuid": "45cf5aba-ac83-4a91-8e84-9836462136a8",
+                "version": 0,
+                "model": {
+                    "type_name": "Dataset",
+                    "version": 2
+                },
+                "additional_metadata": [
+                    {
+                        "provenance": "bia_ingest",
+                        "name": "associations",
+                        "value": {
+                            "associations": [
+                                {
+                                    "image_analysis": null,
+                                    "image_correlation": null,
+                                    "biosample": "Tumor sample from ganglioneuroblastoma patient",
+                                    "image_acquisition": "Fluorescence imaging",
+                                    "specimen": "Preparation and IF-staining of tumor tissue cryosections"
+                                },
+                                {
+                                    "image_analysis": null,
+                                    "image_correlation": null,
+                                    "biosample": "Tumor sample from neuroblastoma patient",
+                                    "image_acquisition": "Fluorescence imaging",
+                                    "specimen": "Preparation and IF-staining of tumor tissue cryosections"
+                                },
+                                {
+                                    "image_analysis": null,
+                                    "image_correlation": null,
+                                    "biosample": "Tumor sample from Wilms tumor patient",
+                                    "image_acquisition": "Fluorescence imaging",
+                                    "specimen": "Preparation and IF-staining of tumor tissue cryosections"
+                                },
+                                {
+                                    "image_analysis": null,
+                                    "image_correlation": null,
+                                    "biosample": "Skin keratinocyte cell line",
+                                    "image_acquisition": "Fluorescence imaging",
+                                    "specimen": "Preparation and IF-staining of HaCaT human skin keratinocyte cell line"
+                                },
+                                {
+                                    "image_analysis": null,
+                                    "image_correlation": null,
+                                    "biosample": "Tumor sample from neuroblastoma patient",
+                                    "image_acquisition": "Fluorescence imaging",
+                                    "specimen": "Preparation and IF-staining of tumor touch imprints and bone marrow cytospin preparations"
+                                },
+                                {
+                                    "image_analysis": null,
+                                    "image_correlation": null,
+                                    "biosample": "Bone marrow sample from neuroblastoma patient",
+                                    "image_acquisition": "Fluorescence imaging",
+                                    "specimen": "Preparation and IF-staining of tumor touch imprints and bone marrow cytospin preparations"
+                                },
+                                {
+                                    "image_analysis": null,
+                                    "image_correlation": null,
+                                    "biosample": "Neuroblastoma cell lines",
+                                    "image_acquisition": "Fluorescence imaging",
+                                    "specimen": "Preparation and IF-staining of neuroblastoma cell line cytospin preparations"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "provenance": "bia_ingest",
+                        "name": "image_acquisition_protocol_uuid",
+                        "value": {
+                            "image_acquisition_protocol_uuid": [
+                                "29f61c5f-ae01-438d-8aa0-d9a787751443"
+                            ]
+                        }
+                    },
+                    {
+                        "provenance": "bia_ingest",
+                        "name": "specimen_imaging_preparation_protocol_uuid",
+                        "value": {
+                            "specimen_imaging_preparation_protocol_uuid": [
+                                "65dec4db-20e8-4505-83a7-6b73a43c64db",
+                                "fa9836ff-dfe2-4bb9-af81-ee450b028a30",
+                                "6b8fd66c-20bc-4cea-9bca-8411965dd7f4",
+                                "a4dad3fc-be06-467a-a52f-bb672e3c623f"
+                            ]
+                        }
+                    },
+                    {
+                        "provenance": "bia_ingest",
+                        "name": "bio_sample_uuid",
+                        "value": {
+                            "bio_sample_uuid": [
+                                "c8c7e2ad-1cf4-49b2-b2a0-1cb033c63dbf",
+                                "f29b5a91-69f1-4921-8d8f-e62ce493c523",
+                                "5fbed112-60d9-4777-83ba-139fa170c05f",
+                                "819dc124-caa5-4fa1-bf99-e47a784b75f0",
+                                "45e124c5-edd3-492b-8f9b-580e7834c623",
+                                "073010c8-ac4d-44ee-a541-0bdaf68cb46c"
+                            ]
+                        }
+                    },
+                    {
+                        "provenance": "bia_ingest",
+                        "name": "uuid_unique_input",
+                        "value": {
+                            "uuid_unique_input": "Study Component-6"
+                        }
+                    }
+                ],
+                "title": "Fluorescence images",
+                "description": "Fluorescent nuclear images of normal or cancer cells from different tissue origins and sample preparation types",
+                "analysis_method": [],
+                "correlation_method": [],
+                "example_image_uri": [],
+                "submitted_in_study_uuid": "0ea2dc40-bf51-4ff8-82e9-2e4cbd8efd71",
+                "acquisition_process": [
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "29f61c5f-ae01-438d-8aa0-d9a787751443",
+                        "version": 0,
+                        "model": {
+                            "type_name": "ImageAcquisitionProtocol",
+                            "version": 3
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Image acquisition-3"
+                                }
+                            }
+                        ],
+                        "title": "Fluorescence imaging",
+                        "protocol_description": "Samples were imaged using 1. an Axioplan-II microscope from Zeiss equipped with a Maerzhaeuser slide scanning stage and a Metasystems Coolcube 1 camera using the Metafer software system (V3.8.6) from Metasystems, 2. an Axioplan-II microscope from Zeiss equipped with a Zeiss AxioCam Mrm 1 using the Metasystems ISIS Software for microscopy image acquisition, 3. an LSM 780 microscope from Zeiss equipped with an Argonlaser 458\u2009nm, a photomultiplier tube (PMT) detector (371\u2013740\u2009nm) and a motorized Piezo Z-stage using the Zeiss Zen software package and 4. a SP8X from Leica equipped with a Diode Laser and a PMT detector (447\u2013468\u2009nm). For the presented dataset, we digitized the DAPI staining pattern representing nuclear DNA. Additional immunofluorescence or FISH stainings were in part available. An automatic illumination time was set as measured by pixel saturation (Metasystems Metafer and ISIS) or defined manually (Zeiss and Leica LSMs). Objectives used were a Zeiss Plan-Apochromat 10\u00d7 objective (Zeiss Axioplan II; numerical aperture 0.45; air), a Zeiss 20\u00d7 Plan-Apochromat (Zeiss LSM 780; numerical aperture 0.8; oil), a Zeiss 20\u00d7 Plan-Apochromat (Leica SP8X; nuermical aperture 0.75; oil), a Zeiss Plan-Neofluar 40\u00d7 objective (Zeiss Axioplan II; numerical aperture 0.75) and a Zeiss Plan-Apochromat 63\u00d7 objective (Zeiss Axioplan II, Zeiss LSM 780 and Leica SP8X; numerical aperture 1.4; oil). Representative field of views (FOVs) were selected according to the following quality criteria: sharpness, intact nuclei and a sufficient number of nuclei.",
+                        "imaging_instrument_description": "Axioplan-II microscope from Zeiss, LSM 780 microscope from Zeiss, SP8X from Leica",
+                        "fbbi_id": [],
+                        "imaging_method_name": [
+                            "fluorescence microscopy"
+                        ]
+                    }
+                ],
+                "specimen_imaging_preparation_protocol": [
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "65dec4db-20e8-4505-83a7-6b73a43c64db",
+                        "version": 0,
+                        "model": {
+                            "type_name": "SpecimenImagingPreparationProtocol",
+                            "version": 3
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Specimen-2"
+                                }
+                            }
+                        ],
+                        "title": "Preparation and IF-staining of tumor tissue cryosections",
+                        "protocol_description": "The fresh-frozen tumor tissues of one ganglioneuroblastoma patient, one neuroblastoma patient and one Wilms tumor patient were embedded into tissue-tek-OCT and 4 \ud835\udf07\ud835\udc5a thick cryosections were prepared. Sections were mounted on Histobond glass slides (Marienfeld), fixed in 4.5% formaledhyde and stained with 4,6-diamino-2-phenylindole (DAPI), a blue fluorescent dye conventionally used for staining of nuclei for cellular imaging techniques. Finally, slides were covered with Vectashield and coverslips were sealed on the slides with rubber cement.",
+                        "signal_channel_information": []
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "fa9836ff-dfe2-4bb9-af81-ee450b028a30",
+                        "version": 0,
+                        "model": {
+                            "type_name": "SpecimenImagingPreparationProtocol",
+                            "version": 3
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Specimen-8"
+                                }
+                            }
+                        ],
+                        "title": "Preparation and IF-staining of HaCaT human skin keratinocyte cell line",
+                        "protocol_description": "The HaCaT cell line, a spontaneously transformed human epithelial cell line from adult skin, was cultivated either in culture flasks or on microscopy glass slides. Cell cultures were irradiated (2 and 6\u2009Gy), harvested, cytospinned, air-dried and IF stained. Cells grown and irradiated on the glass slides were directly subjected to IF staining. Cells were fixed in 4% formaldehyde for 10\u2009minutes at 4\u2009\u00b0C, and were permeabilized with 0.1% sodium dodecyl sulfate (SDS) in PBS for 6\u2009minutes. Slides were mounted with antifade solution Vectashield containing DAPI and coverslips were sealed on the slides with rubber cement.",
+                        "signal_channel_information": []
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "6b8fd66c-20bc-4cea-9bca-8411965dd7f4",
+                        "version": 0,
+                        "model": {
+                            "type_name": "SpecimenImagingPreparationProtocol",
+                            "version": 3
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Specimen-9"
+                                }
+                            }
+                        ],
+                        "title": "Preparation and IF-staining of tumor touch imprints and bone marrow cytospin preparations",
+                        "protocol_description": "Touch imprints were prepared from fresh primary tumors of 4 stage M neuroblastoma patients as previously described. Mononuclear cells were isolated from bone marrow aspirates of 3 stage M neuroblastoma patients by density gradient centrifugation and cytospinned as described. After fixation in 3.7% formaldehyde for 3\u2009minutes, cells were treated according to the Telomere PNA FISH Kit Cy3 protocol (Dako), mounted with Vectashield containing DAPI, covered and sealed.",
+                        "signal_channel_information": []
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "a4dad3fc-be06-467a-a52f-bb672e3c623f",
+                        "version": 0,
+                        "model": {
+                            "type_name": "SpecimenImagingPreparationProtocol",
+                            "version": 3
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Specimen-10"
+                                }
+                            }
+                        ],
+                        "title": "Preparation and IF-staining of neuroblastoma cell line cytospin preparations",
+                        "protocol_description": "STA-NB-10 and CLB-Ma are cell lines derived from neuroblastoma tumor tissue of patients with stage M disease. Preparation and drug-treatment were conducted as described. Briefly, cells were cultured in the absence or presence of 5\u2009nM topotecan, a chemotherapeutic drug for 3 weeks, detached and cytospinned to microscopy glass slides. Preparations were air-dried, fixed in 3.7% formaldehyde, immuno- and DAPI stained, covered and sealed.",
+                        "signal_channel_information": []
+                    }
+                ],
+                "biological_entity": [
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "c8c7e2ad-1cf4-49b2-b2a0-1cb033c63dbf",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 4
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Biosample-1"
+                                }
+                            }
+                        ],
+                        "title": "Tumor sample from ganglioneuroblastoma patient",
+                        "organism_classification": [
+                            {
+                                "additional_metadata": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Schwann cell stroma-rich tissue from a patient with a ganglioneuroblastoma tumor",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "f29b5a91-69f1-4921-8d8f-e62ce493c523",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 4
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Biosample-2"
+                                }
+                            }
+                        ],
+                        "title": "Tumor sample from neuroblastoma patient",
+                        "organism_classification": [
+                            {
+                                "additional_metadata": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Tumor tissue from neuroblastoma patient",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "5fbed112-60d9-4777-83ba-139fa170c05f",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 4
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Biosample-4"
+                                }
+                            }
+                        ],
+                        "title": "Tumor sample from Wilms tumor patient",
+                        "organism_classification": [
+                            {
+                                "additional_metadata": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Wilms tumor tissue",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "819dc124-caa5-4fa1-bf99-e47a784b75f0",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 4
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Biosample-6"
+                                }
+                            }
+                        ],
+                        "title": "Skin keratinocyte cell line",
+                        "organism_classification": [
+                            {
+                                "additional_metadata": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "HaCaT cell line, a spontaneously transformed human epithelial cell line from adult skin",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "45e124c5-edd3-492b-8f9b-580e7834c623",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 4
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Biosample-3"
+                                }
+                            }
+                        ],
+                        "title": "Bone marrow sample from neuroblastoma patient",
+                        "organism_classification": [
+                            {
+                                "additional_metadata": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Bone marrow cells from neuroblastoma patient",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    },
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "073010c8-ac4d-44ee-a541-0bdaf68cb46c",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 4
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Biosample-5"
+                                }
+                            }
+                        ],
+                        "title": "Neuroblastoma cell lines",
+                        "organism_classification": [
+                            {
+                                "additional_metadata": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Patient-derived neuroblastoma cell lines (CLB-Ma, STA-NB10)",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    }
+                ],
+                "annotation_process": [],
+                "other_creation_process": [],
+                "image": [
+                    {
+                        "object_creator": "bia_image_assignment",
+                        "uuid": "0bd6f46e-5fd4-4a62-9924-70eeb98b5db0",
+                        "version": 1,
+                        "model": {
+                            "type_name": "Image",
+                            "version": 2
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "attributes_from_file_reference_2d7824e6-c2ee-47c9-98a9-8b26f032ebf8",
+                                "value": {
+                                    "attributes": {
+                                        "file description": "Raw nuclear images in TIFF format",
+                                        "Diagnosis": "normal (HaCaT)",
+                                        "Preparation": "cellline cytospin",
+                                        "Train-/Testset split": "train",
+                                        "Testset class": "-",
+                                        "Magnification": "63x",
+                                        "Modality": "FM",
+                                        "Device": "Zeiss Axioplan II",
+                                        "Software": "Metafer",
+                                        "Mean BG signal": "19,4",
+                                        "Mean FG signal": "130,4",
+                                        "Signal/Noise": "6,7",
+                                        "S/N Class": ">=4,<40"
+                                    }
+                                }
+                            },
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "file_pattern",
+                                "value": {
+                                    "file_pattern": "dataset/rawimages/normal_13.tif"
+                                }
+                            },
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "2d7824e6-c2ee-47c9-98a9-8b26f032ebf8"
+                                }
+                            },
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "thumbnail_uri",
+                                "value": {
+                                    "thumbnail_uri": [
+                                        "https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD634/886609a6-1a98-4e32-9776-e2a9a4d3ba17/71e7fdd3-14e2-42b5-97f3-cce1af12492c.png"
+                                    ]
+                                }
+                            },
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "recommended_vizarr_representation",
+                                "value": {
+                                    "recommended_vizarr_representation": "bfa4a4d2-0873-4f45-b1c3-4125f82ea650"
+                                }
+                            }
+                        ],
+                        "label": null,
+                        "submission_dataset_uuid": "45cf5aba-ac83-4a91-8e84-9836462136a8",
+                        "creation_process_uuid": "fdff0424-6f45-48dc-b176-20d266a74bb3",
+                        "original_file_reference_uuid": [
+                            "2d7824e6-c2ee-47c9-98a9-8b26f032ebf8"
+                        ]
+                    },
+                    {
+                        "object_creator": "bia_image_assignment",
+                        "uuid": "21cb67a2-bba1-4a49-85fc-ba14a9c40565",
+                        "version": 1,
+                        "model": {
+                            "type_name": "Image",
+                            "version": 2
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "attributes_from_file_reference_269b149b-f5b4-490f-876f-c1baa0b29ac0",
+                                "value": {
+                                    "attributes": {
+                                        "file description": "Raw nuclear images in TIFF format",
+                                        "Diagnosis": "normal (HaCaT)",
+                                        "Preparation": "cellline cytospin",
+                                        "Train-/Testset split": "train",
+                                        "Testset class": "-",
+                                        "Magnification": "63x",
+                                        "Modality": "FM",
+                                        "Device": "Zeiss Axioplan II",
+                                        "Software": "Metafer",
+                                        "Mean BG signal": "13,7",
+                                        "Mean FG signal": "81,4",
+                                        "Signal/Noise": "6",
+                                        "S/N Class": ">=4,<40"
+                                    }
+                                }
+                            },
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "file_pattern",
+                                "value": {
+                                    "file_pattern": "dataset/rawimages/normal_5.tif"
+                                }
+                            },
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "269b149b-f5b4-490f-876f-c1baa0b29ac0"
+                                }
+                            },
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "thumbnail_uri",
+                                "value": {
+                                    "thumbnail_uri": [
+                                        "https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD634/31968bad-fb22-49f1-b782-dda04f9ee78a/56ea80c7-01ac-422c-9c22-c28de48c1e1b.png"
+                                    ]
+                                }
+                            },
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "recommended_vizarr_representation",
+                                "value": {
+                                    "recommended_vizarr_representation": "7689ac81-1271-42c8-8ed3-a5a57590f82c"
+                                }
+                            }
+                        ],
+                        "label": null,
+                        "submission_dataset_uuid": "45cf5aba-ac83-4a91-8e84-9836462136a8",
+                        "creation_process_uuid": "5f19742f-20f9-439c-b0be-63df18c56b99",
+                        "original_file_reference_uuid": [
+                            "269b149b-f5b4-490f-876f-c1baa0b29ac0"
+                        ]
+                    },
+                    {
+                        "object_creator": "bia_image_assignment",
+                        "uuid": "65946fbf-ffe9-485b-b4e9-0119ed3f8b15",
+                        "version": 1,
+                        "model": {
+                            "type_name": "Image",
+                            "version": 2
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "attributes_from_file_reference_06ad7805-67c7-4e4c-95f8-4f7b814d16bd",
+                                "value": {
+                                    "attributes": {
+                                        "file description": "Raw nuclear images in TIFF format",
+                                        "Diagnosis": "Neuroblastoma",
+                                        "Preparation": "cellline cytospin",
+                                        "Train-/Testset split": "test",
+                                        "Testset class": "NB-III: neuroblastoma cell line preparations imaged with LSM modalities",
+                                        "Magnification": "63x",
+                                        "Modality": "LSM",
+                                        "Device": "Leica SP8X",
+                                        "Software": "Leica",
+                                        "Mean BG signal": "0",
+                                        "Mean FG signal": "92,9",
+                                        "Signal/Noise": "2277,6",
+                                        "S/N Class": ">=40"
+                                    }
+                                }
+                            },
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "file_pattern",
+                                "value": {
+                                    "file_pattern": "dataset/rawimages/otherspecimen_8.tif"
+                                }
+                            },
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "06ad7805-67c7-4e4c-95f8-4f7b814d16bd"
+                                }
+                            },
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "thumbnail_uri",
+                                "value": {
+                                    "thumbnail_uri": [
+                                        "https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD634/0bff46f3-6708-4e39-b7e5-be91ffacd68f/b0b90390-b897-419d-ad7f-b89d87d0c89f.png"
+                                    ]
+                                }
+                            },
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "recommended_vizarr_representation",
+                                "value": {
+                                    "recommended_vizarr_representation": "18fd92d2-367a-4f4c-9b3a-bfe7907735b3"
+                                }
+                            }
+                        ],
+                        "label": null,
+                        "submission_dataset_uuid": "45cf5aba-ac83-4a91-8e84-9836462136a8",
+                        "creation_process_uuid": "0d146e91-2d1e-4230-a8e3-123e48057583",
+                        "original_file_reference_uuid": [
+                            "06ad7805-67c7-4e4c-95f8-4f7b814d16bd"
+                        ]
+                    },
+                    {
+                        "object_creator": "bia_image_assignment",
+                        "uuid": "671043d4-d54e-4917-8260-e17aa633a482",
+                        "version": 1,
+                        "model": {
+                            "type_name": "Image",
+                            "version": 2
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "attributes_from_file_reference_ea26099b-ee00-42cb-a8b2-b4d366300ac3",
+                                "value": {
+                                    "attributes": {
+                                        "file description": "Raw nuclear images in TIFF format",
+                                        "Diagnosis": "normal (HaCaT)",
+                                        "Preparation": "cellline cytospin",
+                                        "Train-/Testset split": "train",
+                                        "Testset class": "-",
+                                        "Magnification": "63x",
+                                        "Modality": "FM",
+                                        "Device": "Zeiss Axioplan II",
+                                        "Software": "Metafer",
+                                        "Mean BG signal": "39,6",
+                                        "Mean FG signal": "121",
+                                        "Signal/Noise": "3,1",
+                                        "S/N Class": "<4"
+                                    }
+                                }
+                            },
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "file_pattern",
+                                "value": {
+                                    "file_pattern": "dataset/rawimages/normal_23.tif"
+                                }
+                            },
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "ea26099b-ee00-42cb-a8b2-b4d366300ac3"
+                                }
+                            },
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "thumbnail_uri",
+                                "value": {
+                                    "thumbnail_uri": [
+                                        "https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD634/a9a27619-b417-4a5b-9322-ea5ef38ed747/f1d51ae7-25a1-4fea-ac0c-d5a11f76af7b.png"
+                                    ]
+                                }
+                            },
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "recommended_vizarr_representation",
+                                "value": {
+                                    "recommended_vizarr_representation": "3a3cdc92-b916-4440-a138-7dc744fa2f2e"
+                                }
+                            }
+                        ],
+                        "label": null,
+                        "submission_dataset_uuid": "45cf5aba-ac83-4a91-8e84-9836462136a8",
+                        "creation_process_uuid": "93010f4a-4148-4945-a617-2a7587be3bd5",
+                        "original_file_reference_uuid": [
+                            "ea26099b-ee00-42cb-a8b2-b4d366300ac3"
+                        ]
+                    },
+                    {
+                        "object_creator": "bia_image_assignment",
+                        "uuid": "ae084092-2305-4eef-ba18-b7c1000562a5",
+                        "version": 1,
+                        "model": {
+                            "type_name": "Image",
+                            "version": 2
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "attributes_from_file_reference_28217c7a-fba8-4635-969a-d409f8efc61d",
+                                "value": {
+                                    "attributes": {
+                                        "file description": "Raw nuclear images in TIFF format",
+                                        "Diagnosis": "Neuroblastoma",
+                                        "Preparation": "BM cytospin",
+                                        "Train-/Testset split": "test",
+                                        "Testset class": "NB-I: neuroblastoma bone marrow cytospin preparations",
+                                        "Magnification": "63x",
+                                        "Modality": "FM",
+                                        "Device": "Zeiss Axioplan II",
+                                        "Software": "Metafer",
+                                        "Mean BG signal": "5",
+                                        "Mean FG signal": "105,9",
+                                        "Signal/Noise": "21",
+                                        "S/N Class": ">=4,<40"
+                                    }
+                                }
+                            },
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "file_pattern",
+                                "value": {
+                                    "file_pattern": "dataset/rawimages/Neuroblastoma_16.tif"
+                                }
+                            },
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "28217c7a-fba8-4635-969a-d409f8efc61d"
+                                }
+                            },
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "thumbnail_uri",
+                                "value": {
+                                    "thumbnail_uri": [
+                                        "https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD634/a2bced14-e604-4c9b-9601-6b9e55f5dab9/87469f31-26c3-43e0-a961-039d6d8b826d.png"
+                                    ]
+                                }
+                            },
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "recommended_vizarr_representation",
+                                "value": {
+                                    "recommended_vizarr_representation": "8c72c8bb-7d9c-432e-ba44-e2d2133d5b00"
+                                }
+                            }
+                        ],
+                        "label": null,
+                        "submission_dataset_uuid": "45cf5aba-ac83-4a91-8e84-9836462136a8",
+                        "creation_process_uuid": "c5f907e5-6fd8-4d66-8ba8-55ba7d5cbf4b",
+                        "original_file_reference_uuid": [
+                            "28217c7a-fba8-4635-969a-d409f8efc61d"
+                        ]
+                    },
+                    {
+                        "object_creator": "bia_image_assignment",
+                        "uuid": "da586fce-9f04-44db-b741-102fdcf9430e",
+                        "version": 1,
+                        "model": {
+                            "type_name": "Image",
+                            "version": 2
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "attributes_from_file_reference_6d657a2d-fc6a-44c6-ba75-510c1ccd1701",
+                                "value": {
+                                    "attributes": {
+                                        "file description": "Raw nuclear images in TIFF format",
+                                        "Diagnosis": "normal (HaCaT)",
+                                        "Preparation": "cellline cytospin",
+                                        "Train-/Testset split": "test",
+                                        "Testset class": "NC-II: normal cells cytospin preparations with low signal-to-noise ratio",
+                                        "Magnification": "40x",
+                                        "Modality": "FM",
+                                        "Device": "Zeiss Axioplan II",
+                                        "Software": "Metafer",
+                                        "Mean BG signal": "29,4",
+                                        "Mean FG signal": "114",
+                                        "Signal/Noise": "3,9",
+                                        "S/N Class": "<4"
+                                    }
+                                }
+                            },
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "file_pattern",
+                                "value": {
+                                    "file_pattern": "dataset/rawimages/normal_37.tif"
+                                }
+                            },
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "6d657a2d-fc6a-44c6-ba75-510c1ccd1701"
+                                }
+                            },
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "thumbnail_uri",
+                                "value": {
+                                    "thumbnail_uri": [
+                                        "https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD634/edde8f1d-387f-4271-9f86-3aa6ec04aa21/2fad2229-a5fe-4fe1-b2b3-b3dbd8a64c7e.png"
+                                    ]
+                                }
+                            },
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "static_display_uri",
+                                "value": {
+                                    "static_display_uri": [
+                                        "https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD634/edde8f1d-387f-4271-9f86-3aa6ec04aa21/839e9e54-4cb6-47c3-9e74-770b267c8c43.png"
+                                    ]
+                                }
+                            },
+                            {
+                                "provenance": "bia_image_assignment",
+                                "name": "recommended_vizarr_representation",
+                                "value": {
+                                    "recommended_vizarr_representation": "bc6852fd-4f85-4f7d-a1f8-189301248e1f"
+                                }
+                            }
+                        ],
+                        "label": null,
+                        "submission_dataset_uuid": "45cf5aba-ac83-4a91-8e84-9836462136a8",
+                        "creation_process_uuid": "cd735974-aede-4113-9cc0-7d51b10d9497",
+                        "original_file_reference_uuid": [
+                            "6d657a2d-fc6a-44c6-ba75-510c1ccd1701"
+                        ]
+                    }
+                ]
+            },
+            {
+                "image_count": 0,
+                "file_reference_count": 388,
+                "file_reference_size_bytes": 399220454,
+                "file_type_counts": {
+                    "file": 388
+                },
+                "object_creator": "bia_ingest",
+                "uuid": "b861c692-68f8-4c41-b583-162d4a44f793",
+                "version": 0,
+                "model": {
+                    "type_name": "Dataset",
+                    "version": 2
+                },
+                "additional_metadata": [
+                    {
+                        "provenance": "bia_ingest",
+                        "name": "annotation_method_uuid",
+                        "value": {
+                            "annotation_method_uuid": [
+                                "66139451-bcbe-475b-8c4b-1aa6dd0cf498"
+                            ]
+                        }
+                    },
+                    {
+                        "provenance": "bia_ingest",
+                        "name": "uuid_unique_input",
+                        "value": {
+                            "uuid_unique_input": "Annotations-29"
+                        }
+                    }
+                ],
+                "title": "Segmentation masks",
+                "description": null,
+                "analysis_method": [],
+                "correlation_method": [],
+                "example_image_uri": [],
+                "submitted_in_study_uuid": "0ea2dc40-bf51-4ff8-82e9-2e4cbd8efd71",
+                "acquisition_process": [],
+                "specimen_imaging_preparation_protocol": [],
+                "biological_entity": [],
+                "annotation_process": [
+                    {
+                        "default_open": true,
+                        "object_creator": "bia_ingest",
+                        "uuid": "66139451-bcbe-475b-8c4b-1aa6dd0cf498",
+                        "version": 0,
+                        "model": {
+                            "type_name": "AnnotationMethod",
+                            "version": 4
+                        },
+                        "additional_metadata": [
+                            {
+                                "provenance": "bia_ingest",
+                                "name": "uuid_unique_input",
+                                "value": {
+                                    "uuid_unique_input": "Annotations-29"
+                                }
+                            }
+                        ],
+                        "title": "Segmentation masks",
+                        "protocol_description": "",
+                        "annotation_criteria": "The annotation of nuclei in tissue sections or tumor touch imprints is challenging and may not be unambiguous due to out-of-focus light or nuclei, damaged nuclei or nuclei presenting with modified morphology due to the slide preparation procedure. We defined the following criteria to annotate nuclear images: Only intact nuclei are annotated, even if the nuclear intensity is low in comparison to all other nuclei present. Nuclei have to be in focus. If parts of a nucleus are out of focus, only the part of the nucleus being in focus is annotated. Nuclear borders have to be annotated as exact as resolution and blurring allows for. Nuclei are not annotated if their morphology was heavily changed due to the preparation procedure. Nuclei from dividing cells are annotated as one nucleus unless clear borders can be distinguished between the resulting new nuclei.",
+                        "annotation_coverage": null,
+                        "transformation_description": null,
+                        "spatial_information": null,
+                        "method_type": [
+                            "other"
+                        ],
+                        "annotation_source_indicator": null
+                    }
+                ],
+                "other_creation_process": [],
+                "image": []
+            }
+        ]
+    }
+}

--- a/src/pages/galleries/ai/image/[uuid].astro
+++ b/src/pages/galleries/ai/image/[uuid].astro
@@ -1,157 +1,243 @@
 ---
 import BaseLayoutWithBreadcrumbs from '../../../../layouts/BaseLayoutWithBreadcrumbs.astro';
-import SourceImage from "../../../../components/SourceImage.astro"
 import WebsiteStateButton from '../../../../components/WebsiteStateButton.astro';
-
-import exports from "../../../../data/old-export-format/bia-images-export.json";
+import { taxonRender } from "../../../../components/SharedJSFunctions.js";
+//import exports from "../../../../data/old-export-format/bia-images-export.json";
+import exports from "../../../../data/current-export-mock/bia-ai-image-export.json";
+import datasets from "../../../../data/current-export-mock/bia-ai-dataset-export.json";
 import studyData from "../../../../data/old-export-format/bia-export.json";
-import AIStudyData from "../../../../data/old-export-format/bia-ai-export.json";
+import AIStudyData from "../../../../data/current-export-mock/bia-ai-study-export.json";
 import SpatialomicsStudyData from "../../../../data/old-export-format/bia-spatialomics-export.json";
-
-
+import "../../../../styles/image_slider.css"
 export function getStaticPaths() {
-  return Object.keys(exports["images"]).map((uuid) => {
+  return Object.keys(exports).map((uuid) => {
     return {
       params:  { uuid: uuid }
     };
   });
 }
 
-const { uuid } = Astro.params;
-
-const image = exports["images"][uuid];
-
-const tissue_x = (1e6 * image.PhysicalSizeX * image.sizeX).toPrecision(2);
-const tissue_y = (1e6 * image.PhysicalSizeY * image.sizeY).toPrecision(2);
-
-
-function getStudyData(accessionID, StudyData, AIStudyData, SpatialomicsStudyData) {
-    if (accessionID in StudyData["datasets"]) {
-        return StudyData["datasets"][accessionID]
-    } else if (accessionID in AIStudyData["datasets"]) {
-        return AIStudyData["datasets"][accessionID]
-    } else if (accessionID in SpatialomicsStudyData["datasets"]) {
-        return SpatialomicsStudyData["datasets"][accessionID]
-    }
+function getAttributes(image) {
+  return image.additional_metadata.find(meta =>
+    meta.name.startsWith("attributes_from_file_reference")
+  )?.value?.attributes || {};
 }
 
-const study_info = getStudyData(image.study_accession_id, studyData, AIStudyData, SpatialomicsStudyData)
+function getMicronSize(rep) {
+  return [
+    (1e6 * rep.voxel_physical_size_x ** 2).toPrecision(2),
+    (1e6 * rep.voxel_physical_size_y ** 2).toPrecision(2)
+  ];
+}
 
-const base_img_s3_url = image.vizarr_uri.replace('https://uk1s3.embassy.ebi.ac.uk/bia-zarr-test/vizarr/index.html?source=','')
+function getStudyData(datasetID) {
+  const accessionID = datasets[datasetID].submitted_in_study.accession_id;
+  return (
+    studyData.datasets[accessionID] ||
+    AIStudyData[accessionID] ||
+    SpatialomicsStudyData.datasets[accessionID]
+  );
+}
 
+function getTaxons(study) {
+    const taxonHtmlList = []
+    const taxonList = []
+    for (var dataset of study.dataset) {
+        for (var biosample of dataset.biological_entity) {
+            for (var taxon of biosample.organism_classification) {
+                if (!taxonList.some(txnFinal => txnFinal.common_name === taxon.common_name || txnFinal.scientific_name === taxon.scientific_name )) {
+                    taxonList.push(taxon)
+                    taxonHtmlList.push(taxonRender(taxon))
+                }
+            }
+        }
+    }
+    return taxonHtmlList
+}
+
+const { uuid } = Astro.params;
+const image = exports[uuid];
+let sourceImage;
+let annotatedImages = [];
+
+if (image.creation_process?.input_image_uuid?.[0]) {
+  sourceImage = exports[image.creation_process.input_image_uuid[0]];
+  annotatedImages = Object.values(exports).filter(img =>
+    img.creation_process?.input_image_uuid?.[0] === sourceImage.uuid
+  );
+} else {
+  sourceImage = image;
+  annotatedImages = Object.values(exports).filter(img =>
+    img.creation_process?.input_image_uuid?.[0] === uuid
+  );
+}
+let annotatedImage = annotatedImages[0]
+
+const annotatedImageAttributes = getAttributes(annotatedImage);
+const sourceImageAtrributes = getAttributes(sourceImage)
+const annotatedImageRep = annotatedImage.representation.find((r) => r.image_format === ".ome.zarr");
+const sourceImageRep = sourceImage.representation.find((r) => r.image_format === ".ome.zarr");
+const [annotated_tissue_x, annotated_tissue_y] = getMicronSize(annotatedImageRep)
+const [source_tissue_x, source_tissue_y] = getMicronSize(sourceImageRep)
+const sourceImgS3Url = sourceImageRep.file_uri[0].replace('https://uk1s3.embassy.ebi.ac.uk/bia-zarr-test/vizarr/index.html?source=','')
+const annotatedImgS3Url = annotatedImageRep.file_uri[0].replace('https://uk1s3.embassy.ebi.ac.uk/bia-zarr-test/vizarr/index.html?source=','')
+const studyInfo = getStudyData(sourceImage.submission_dataset_uuid);
+const organism = getTaxons(studyInfo).join(", ");
+const imagingMethod = studyInfo.dataset.find((d) => d['uuid'] == sourceImage.submission_dataset_uuid).acquisition_process[0].imaging_method_name.join(", ")
+const annotationTypeMethod = studyInfo.dataset.find((d) => d['uuid'] == annotatedImage.submission_dataset_uuid).annotation_process[0] || {title: "", annotation_criteria:""};
 const breadcrumbs = [
   "/bioimage-archive",
   "/bioimage-archive/galleries",
   "/bioimage-archive/galleries/ai",
   "/bioimage-archive/galleries/ai/ai-ready-studies",
-  `/bioimage-archive/galleries/ai/ai-ready-study/${image.study_accession_id}`,
+  `/bioimage-archive/galleries/ai/ai-ready-study/${studyInfo.accession_id}`,
 ]
-
 ---
-
-<BaseLayoutWithBreadcrumbs pageTitle={image["alias"]} breadcrumbs={breadcrumbs}>
+<BaseLayoutWithBreadcrumbs pageTitle={uuid} breadcrumbs={breadcrumbs}>
     <div class="vf-stack vf-stack--500">
         <section class="vf-content | embl-grid embl-grid--has-centered-content">
-            <div></div>
-            <div>
-                <h1 class="vf-intro__heading vf-intro__heading--has-tag">{ image.study_accession_id }:{ image.alias }
+        <div>
+        </div>
+        <div>
+        <h1 class="vf-intro__heading vf-intro__heading--has-tag">{ studyInfo.accession_id }
                     <WebsiteStateButton/>
                 </h1>
-                <h2 class="vf-intro__subheading">{image.name}</h2>
-                {image.original_relpath}
-                <p class="studytitle">{image.study_title}</p>
-            </div>
-            <div>
-                Released {image.release_date}<br>
-                Modified 2023-05-07
+                <p class="studytitle">{studyInfo.title}</p>
+            <a href=`/bioimage-archive/galleries/ai/ai-ready-study/${studyInfo.accession_id}`>
+                    <button class="vf-button vf-button--primary vf-button--sm">Study Page</button>
+                </a>
+        </div>
+        <div>
+        </div>
+        </section>
+        <section class="vf-content "><a href={"/bioimage-archive/help/downloading-data#aws_client_download"}>How to download these images</a><br/></section>    
+        <section class="vf-content">
+            <div class="vf-grid vf-grid__col-2">
+                <div><h3><span>Source Image</span></h3></div>
+                <div><h3><span>Annotated Image <span id="AnnotatedImageLength">1</span> of {annotatedImages.length}</span></h3></div>
+            </div>   
+        </section>
+        <section class="vf-content">
+            <div style="display: flex; gap: 1rem;">
+                <iframe src={sourceImageRep.file_uri[0]} style="flex:1;height: 500px;"></iframe>
+                <div style="flex: 1; position: relative; overflow: hidden;">
+                    <button onclick="slide(-1)" class="slider-left-button"></button>
+                    <div id="slider">
+                        {annotatedImages.map((img) => {
+                            const rep = img.representation.find((r) => r.image_format === ".ome.zarr");
+                            return (
+                                <iframe src={rep.file_uri[0]} style="height: 500px; min-width: 100%; border: none;" id={img.uuid}></iframe>
+                            );
+                            })}
+                    </div>
+                    <button onclick="slide(1)" class="slider-right-button"></button>
+                </div>   
             </div>
         </section>
-        <section class="vf-content | embl-grid embl-grid--has-centered-content">
-            <div>
+        <section class="vf-content">
+            <div style="display: flex; justify-content: space-between; gap: 2rem;">
+            <div style="flex: 1;">
+                <a href={sourceImageRep.file_uri[0]}><button class="vf-button vf-button--primary vf-button--sm">Open Source Image in Vizarr viewer</button></a> 
+                <a href={"https://kitware.github.io/itk-vtk-viewer/app/?fileToLoad="+sourceImgS3Url}><button class="vf-button vf-button--primary vf-button--sm">Open Source Image in ITK viewer</button></a>
+                <button class="vf-button vf-button--primary vf-button--sm" id="CopyURLButton" data-url={sourceImgS3Url}>Copy Source Image OME-Zarr URI</button><br/>
+                
                 <h3>Image metadata</h3>
-                <b>Image size: </b> {tissue_x}μm x {tissue_y}μm<br>
-                {image.sizeX} x {image.sizeY} pixels<br />
-                {image.sizeC} channels
+                <b>Image size: </b> {source_tissue_x}μm x {source_tissue_y}μm<br>
+                {sourceImageRep.size_x} x {sourceImageRep.size_y} pixels<br />
+                {sourceImageRep.size_c} channels<br />
+                {sourceImageRep.size_t} timesteps
                 <br /> <br />
-                {Object.entries(image.attributes).map(([key, value]) => (
-                    <p>{key}: {value}</p>
+                <h3>Additional metadata</h3>
+                {Object.entries(sourceImageAtrributes).map(([key, value]) => (
+                    <>
+                    <b>{key}:</b> {value}<br />
+                    </>
                 ))}
             </div>
-            <div>
-                <iframe style="width: 100%; height: 500px" name="vizarr" src={image.vizarr_uri}></iframe>
+            <div style="flex: 1;">
+                
+                <a href={annotatedImageRep.file_uri[0]} id="OpenAnnotationInVizarr"><button class="vf-button vf-button--primary vf-button--sm">Open Annotation in Vizarr viewer</button></a>
+                <a href={"https://kitware.github.io/itk-vtk-viewer/app/?fileToLoad="+annotatedImgS3Url} id="OpenAnnotationInITK"><button class="vf-button vf-button--primary vf-button--sm">Open Annotation in ITK viewer</button></a>
+                <button class="vf-button vf-button--primary vf-button--sm" id="CopyAnnotationButton" data-url={annotatedImgS3Url}>Copy Annotation OME-Zarr URI</button>
+                <h3>Image metadata</h3>
+                <b>Image size: </b> <span id="annotated-size">{annotated_tissue_x}μm x {annotated_tissue_y}μm</span><br>
+                <span id="annotated-pixels">{annotatedImageRep.size_x} x {annotatedImageRep.size_y} pixels</span><br />
+                <span id="annotated-channels">{annotatedImageRep.size_c} channels</span><br />
+                <span id="annotated-timesteps">{annotatedImageRep.size_t} timesteps</span><br /><br />
+                <h3>Additional metadata</h3>
+                <div id="annotated-metadata">
+                {Object.entries(annotatedImageAttributes).map(([key, value]) => (
+                    <>
+                    <b>{key}:</b> {value}<br />
+                    </>
+                ))}
+                </div>
             </div>
-            <div>
-                <h3>Access images</h3>
-                License: <a href="https://creativecommons.org/publicdomain/zero/1.0/">https://creativecommons.org/publicdomain/zero/1.0/</a>> <br/>
-                <br/>
-                <a href={"/bioimage-archive/help/downloading-data#aws_client_download"}>How to download this image</a>
-                <br/>
-                <br/>
-
-                <button class="vf-button vf-button--primary vf-button--sm" id="CopyURLButton" data-url={base_img_s3_url}>Copy OME-Zarr URI</button>
-                <h3>Visualise</h3>
-                <a href={image.vizarr_uri}>
-                    <button class="vf-button vf-button--primary vf-button--sm">Open in Vizarr viewer</button>
-                </a>
-                <a href={image.itk_uri}>
-                    <button class="vf-button vf-button--primary vf-button--sm">Open in ITK viewer</button>
-                </a>
-
-                <script>
-
-                    let copyUrlButton = document.getElementById("CopyURLButton")
-                    let originalText = copyUrlButton.innerText;
-                    copyUrlButton.onclick=async() => {
-                        await copyUrl(copyUrlButton.dataset.url, copyUrlButton, originalText);
-                    };
-
-                    async function copyUrl(url, button, originalText) {
-                        await navigator.clipboard.writeText(url);
-                        button.innerText = "URI Copied";
-                        setTimeout(() => {
-                            button.innerText = originalText;
-                        }, 700);
-                    }
-
-                </script>
             </div>
         </section>
-        { ( image.source_image_uuid != null ) &&
-            <SourceImage image={ image} />
-        }
+        <div class="vf-divider" />
         <section class="vf-content | embl-grid embl-grid--has-centered-content">
-            <div>
-                <h3>Study</h3>
-            </div>
-            <div><b>Title:</b> {image.study_title}</div>
-            <div></div>
+        <div><h3>Annotated Dataset</h3></div>
+        <div>
+            <h4>{datasets[sourceImage.submission_dataset_uuid].title}</h4>
+            <b>License: </b><a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0</a><br />
+            <b>Organism: </b> <span set:html={organism}/><br />
+            <b>Imaging method: </b> {imagingMethod}<br />
+            <b>Annotation type: </b><span id="annotation-type">{annotationTypeMethod.title}</span> <br />
+            <b>Annotation method: </b><span id="annotation-method">{annotationTypeMethod.annotation_criteria}</span> <br />
+        </div>
         </section>
-        <section class="vf-content | embl-grid embl-grid--has-centered-content">
-            <div>
-                <h3>Biosample</h3>
-            </div>
-            <div>
-                <b>Organism:</b> {study_info.organism}<br>
-                <b>Biological entity: </b>
-            </div>
-            <div></div>
-        </section>
-        <section class="vf-content | embl-grid embl-grid--has-centered-content">
-            <div>
-                <h3>Specimen</h3>
-            </div>
-            <div>
-                <b>Sample preparation:</b> <br>
-            </div>
-            <div></div>
-        </section>
-        <section class="vf-content | embl-grid embl-grid--has-centered-content">
-            <div>
-                <h3>Image acquisition</h3>
-            </div>
-            <div>
-                <b>Imaging Method:</b> <br>
-            </div>
-            <div></div>
-        </section>
+        <script type="application/json" id="images-json" set:html={JSON.stringify(annotatedImages)} />
+        <script type="application/json" id="study-json" set:html={JSON.stringify(studyInfo.dataset)} />
+        <script type="module">
+            let currentSlide = 0;
+            const slider = document.getElementById("slider");
+            const slides = slider.children;
+            const updateMetadata = (uuid) => {
+                const image = JSON.parse(document.getElementById("images-json").textContent).find(ai => ai.uuid === uuid)
+                const rep = image.representation.find((r) => r.image_format === ".ome.zarr");
+                const attributes = image.additional_metadata.find(meta =>
+                    meta.name.startsWith("attributes_from_file_reference")
+                )?.value?.attributes || {};
+                const micronX = (1e6 * rep.voxel_physical_size_x ** 2).toPrecision(2);
+                const micronY = (1e6 * rep.voxel_physical_size_y ** 2).toPrecision(2);
+                document.getElementById("annotated-size").innerText = `${micronX}μm x ${micronY}μm`;
+                document.getElementById("annotated-pixels").innerText = `${rep.size_x} x ${rep.size_y} pixels`;
+                document.getElementById("annotated-channels").innerText = `${rep.size_c} channels`;
+                document.getElementById("annotated-timesteps").innerText = `${rep.size_t} timesteps`;
+                const metaContainer = document.getElementById("annotated-metadata");
+                metaContainer.innerHTML = "";
+                Object.entries(attributes).forEach(([key, value]) => {
+                    const line = document.createElement("div");
+                    line.innerHTML = `<b>${key}:</b> ${value}<br />`;
+                    metaContainer.appendChild(line);
+                });
+                const s3url = rep.file_uri[0].replace('https://uk1s3.embassy.ebi.ac.uk/bia-zarr-test/vizarr/index.html?source=', '');
+                const copyBtn = document.getElementById("CopyAnnotationButton");
+                copyBtn.dataset.url = s3url;
+                document.getElementById("OpenAnnotationInVizarr").href = rep.file_uri[0];
+                document.getElementById("OpenAnnotationInITK").fred = "https://kitware.github.io/itk-vtk-viewer/app/?fileToLoad="+s3url;
+                const studyInfo = JSON.parse(document.getElementById("study-json").textContent)
+                const annotationTypeMethod = studyInfo.dataset.find((d) => d['uuid'] == image.submission_dataset_uuid).annotation_process[0] || {title: "", annotation_criteria:""};
+                document.getElementById("annotation-type").innerText = annotationTypeMethod.title;
+                document.getElementById("annotation-method").innerText = annotationTypeMethod.annotation_criteria
+            };
+            window.slide = function(direction) {
+                const total = slides.length;
+                currentSlide = (currentSlide + direction + total) % total;
+                slider.style.transform = `translateX(-${currentSlide * 100}%)`;
+
+                const currentUUID = slides[currentSlide].id;
+                document.getElementById("AnnotatedImageLength").innerText = currentSlide+1;
+                updateMetadata(currentUUID);
+            };
+            const originalText = "Copy Annotation OME-Zarr URI";
+            document.getElementById("CopyAnnotationButton").onclick = async (e) => {
+                const url = e.target.dataset.url;
+                await navigator.clipboard.writeText(url);
+                e.target.innerText = "URI Copied";
+                setTimeout(() => e.target.innerText = originalText, 700);
+            };
+            updateMetadata(slides[0].id);
+        </script>
 </BaseLayout>

--- a/src/styles/image_slider.css
+++ b/src/styles/image_slider.css
@@ -1,0 +1,36 @@
+#slider{
+    display: flex; 
+    transition: transform 0.3s ease;
+}
+
+.slider-right-button{
+    position:absolute; 
+    right:0;
+    margin-right: 3%; 
+    top:50%; 
+    z-index:10; 
+    padding: 10px; 
+    border: solid white;
+    background-color: transparent;
+    background-repeat: no-repeat;
+    border-width: 0 10px 10px 0;
+    display: inline-block;
+    transform: rotate(45deg);
+    -webkit-transform: rotate(-45deg)
+}
+
+.slider-left-button{
+    position:absolute; 
+    left:0;
+    margin-left: 3%; 
+    top:50%; 
+    z-index:10;
+    padding: 10px; 
+    border: solid white;
+    background-color: transparent;
+    background-repeat: no-repeat;
+    border-width: 0 10px 10px 0;
+    display: inline-block;
+    transform: rotate(45deg);
+    -webkit-transform: rotate(135deg)
+}


### PR DESCRIPTION
These changes use the current export format for the image page of ai-ready-studies. 

Clickup ticket: https://app.clickup.com/t/8699gv5ww

# Not to be merged till all changes are made. 

As these mock dataset will break pages for the other studies as the mock dataset only have 3 images. I will include other images in coming commits and also plan on updating the study pages to use current export format. 

# Idea of image pages to look like this
![Screenshot 2025-06-25 at 13 33 06](https://github.com/user-attachments/assets/84c03ff7-4900-487c-9333-ee1048c597d1)
![Screenshot 2025-06-25 at 13 33 30](https://github.com/user-attachments/assets/a8a4d6a6-e0e5-471b-86a2-bb5c667b0521)
