### PR TITLE
use ES views

### DIFF
--- a/src/components/DatasetFilesTable.astro
+++ b/src/components/DatasetFilesTable.astro
@@ -79,7 +79,7 @@ const sectionClass = page && page === "gallery" ? "content": "intro";
                         processing: true,
                         scrollX: true,
                         columnDefs: [{ type: "natural", targets: 0 }],
-                        createdRow: (row, data) => {
+                        createdRow: (row) => {
                             // Attach event listener to the button after row creation
                             $(row).find(".copy-btn").on("click", function () {
                                 const link = $(this).data("uri");

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -7,23 +7,23 @@ import elixirCoreLogo from "../assets/bioimage-archive/ELIXIR service logos_CDR_
   <section class="vf-gird bia-footer-inner">
     <div class="bia-footer-block" style="flex: 1;justify-content: flex-start;">
       <div class="elixir-logo-kite" aria-hidden="true">
-        <a href="https://elixir-europe.org/platforms/data/elixir-deposition-databases" class="vf-link"><img src={elixirDepoLogo.src} style="width: 100px; height: 100px" loading="lazy"/></a>
+        <a target="_blank" href="https://elixir-europe.org/platforms/data/elixir-deposition-databases" class="vf-link"><img src={elixirDepoLogo.src} style="width: 100px; height: 100px" loading="lazy"/></a>
       </div>
       <div class="elixir-logo-kite" aria-hidden="true">
-        <a href="https://elixir-europe.org/platforms/data/core-data-resources" class="vf-link"><img src={elixirCoreLogo.src} style="width: 100px; height: 100px" loading="lazy"/> </a>
+        <a target="_blank" href="https://elixir-europe.org/platforms/data/core-data-resources" class="vf-link"><img src={elixirCoreLogo.src} style="width: 100px; height: 100px" loading="lazy"/> </a>
       </div>
       <p class="bia-footer-text">
-        The BioImage Archive is an ELIXIR <a href="https://elixir-europe.org/platforms/data/elixir-deposition-databases" class="vf-link">Deposition Database</a> and <a href="https://elixir-europe.org/platforms/data/core-data-resources" class="vf-link">Core Data Resource</a>.
+        The BioImage Archive is an ELIXIR <a target="_blank" href="https://elixir-europe.org/platforms/data/elixir-deposition-databases" class="vf-link">Deposition Database</a> and <a target="_blank" href="https://elixir-europe.org/platforms/data/core-data-resources" class="vf-link">Core Data Resource</a>.
       </p>
     </div>
     <div class="bia-footer-block" style="flex: 1;justify-content: flex-end;text-align: left;">
       <div class="bia-footer-text">
         <div>
           The BioImage Archive is developed in collaboration with
-          <a href="http://www.eurobioimaging.eu/" class="vf-link">Euro-BioImaging</a>.
+          <a target="_blank" href="http://www.eurobioimaging.eu/" class="vf-link">Euro-BioImaging</a>.
         </div>
       </div>
-      <a href="http://www.eurobioimaging.eu/" class="vf-link"><div class="eubi-logo-kite" aria-hidden="true"></div></a>
+      <a target="_blank" href="http://www.eurobioimaging.eu/" class="vf-link"><div class="eubi-logo-kite" aria-hidden="true"></div></a>
     </div>
   </section>
 </footer>

--- a/src/components/ImageTableRow.astro
+++ b/src/components/ImageTableRow.astro
@@ -1,5 +1,5 @@
 ---
-import { getThumbnail, formatBytesToHumanSize, getSimpleAttributeValue } from "./SharedJSFunctions";
+import { getThumbnail, formatBytesToHumanSize } from "./SharedJSFunctions";
 
 const { image, datasetTitle, imagePageRoot } = Astro.props;
 

--- a/src/components/News.astro
+++ b/src/components/News.astro
@@ -21,7 +21,7 @@ const items = await getCollection("news_articles");
                     </div>
                     <div>
                         {news.data.cover?.src && (
-                        <a href={news.data.figureLink} class="vf-link logo-img">
+                        <a href={news.data.figureLink} class="vf-link logo-img" target="_blank">
                             <img class="vf-figure__image" src={news.data.cover.src} alt={news.data.imageAlt} loading="lazy" style="max-height: 200px;"/>
                         </a>
                         )}

--- a/src/components/SharedInterface.astro
+++ b/src/components/SharedInterface.astro
@@ -46,6 +46,7 @@ export interface Image {
   creation_process?: ImageCreationProcess;
   licence_details: Licence;
   accession_id: string;
+  file_list_attributes: any[];
 }
 
 export interface SpecimenInfo {

--- a/src/components/SharedInterface.astro
+++ b/src/components/SharedInterface.astro
@@ -15,6 +15,8 @@ export interface Study {
   description?: string;
   licence?: string;
   keyword?: any[]
+  image?: any[]
+  annotation_type?: any[]
 }
 export interface Studies {
     accession_id: Study;

--- a/src/components/SharedInterface.astro
+++ b/src/components/SharedInterface.astro
@@ -14,10 +14,46 @@ export interface Study {
   additional_metadata?: any;
   description?: string;
   licence?: string;
+  licence_details: Licence;
   keyword?: any[]
   image?: any[]
   annotation_type?: any[]
 }
 export interface Studies {
     accession_id: Study;
+}
+
+export interface Licence {
+  uri: string;
+  log_uri: string;
+  label: string;
+}
+
+export interface ImageCreationProcess {
+  input_image_uuid?: string[];
+  subject?: any;
+  acquisition_process?: any[];
+  annotation_method?: any[];
+  protocol?: any[];
+}
+
+export interface Image {
+  representation: any[];
+  uuid: string;
+  additional_metadata?: any[];
+  file_path?: string[];
+  submission_dataset_uuid: string;
+  creation_process?: ImageCreationProcess;
+  licence_details: Licence;
+  accession_id: string;
+}
+
+export interface SpecimenInfo {
+  uuid: string;
+  [key: string]: any;
+}
+
+export interface ImageRep {
+  uuid: string;
+  [key: string]: any;
 }

--- a/src/components/SharedJSFunctions.js
+++ b/src/components/SharedJSFunctions.js
@@ -56,11 +56,20 @@ export function getSimpleAttributeValue(obj, attrName) {
 }
   
 export function getLicenceLogo(licenceURL){
-    const licenceImage = licenceURL.split("/").slice(-3)[0]
     const isCreativeCommons = licenceURL.includes("creativecommons");
-    var logoURL = isCreativeCommons? "http://mirrors.creativecommons.org/presskit/buttons/88x31/svg/": "";
-    logoURL += licenceImage === "zero"? "cc-zero.svg": `${licenceImage}.svg`;
-    return logoURL
+    if (isCreativeCommons){
+      var logoURL = "http://mirrors.creativecommons.org/presskit/buttons/88x31/svg/";
+      if (licenceURL.includes("publicdomain/zero")){
+        return logoURL+= "cc-zero.svg"
+      }
+      const licenceImage = licenceURL.split("licenses")[1].split("/")[1]
+      logoURL += `${licenceImage}.svg`;
+      return logoURL
+    }
+    else{
+      return ""
+    }
+    
 
 }  
 export function getDatasetStatsByUUID(study) {
@@ -98,6 +107,16 @@ export function getTaxons(study) {
     }
     return taxonHtmlList
 }
+export function renderTaxonList(study) {
+    const taxonList = getTaxons(study)
+    return taxonList.reduce(formatListItem, "")
+}
+
+export function highlightOrganism(study, query){
+    const text = renderTaxonList(study)
+    return query && text? applyHighlight(text, query): text;
+}
+
 
 export function getAnnotationType(datasets) {
   const annotationTypes = new Set();
@@ -264,7 +283,7 @@ export async function getStudyFromApiByUUID(uuid){
 }
 
 export async function getStudyFromApiByAccession(accessionID){
-    const response = await getFromAPI(`${PUBLIC_SEARCH_API}/website/study?query=${accessionID}`);
+    const response = await getFromAPI(`${PUBLIC_SEARCH_API}/website/study?facet.accession_id=${accessionID}`);
     const study = response?.hits?.hits?.find(
         (hit) => hit._source?.accession_id === accessionID
       )?._source || undefined;
@@ -404,8 +423,31 @@ export function getTutorialURLs(urlType){
     return urlType === "submission"? `${quickTourURL}/submitting-data-to-bioimage-archive-2/submission/` : quickTourURL
 }
 
-export function applyHighlight(text, highlight, query) {
-const out = text ?? "";
+export function highlightText(text, query) {
+  return query && text ? applyHighlight(text, query) : text;
+}
+
+export function formatUniqueList(values = [], { sort = true, transform = value => value } = {}) {
+  if(values == null){
+    return ""
+  }
+  const items = values
+    .filter(Boolean)
+    .map(transform);
+
+  const unique = [...new Set(items)];
+  if (sort) unique.sort();
+
+  return unique.join(", ");
+}
+
+export function formatHighlightedList(values = [], query, options = {}) {
+  return highlightText(formatUniqueList(values, options), query);
+}
+
+
+export function applyHighlight(text, query) {
+  const out = text ?? "";
   if (!query) return out;
 
   // If it's already highlighted, keep it (prevents double-highlighting / nesting)

--- a/src/components/SharedJSFunctions.js
+++ b/src/components/SharedJSFunctions.js
@@ -9,14 +9,12 @@ export function getPlaceholderHeroImage(accessionID) {
 }
 
 export function getStudyImage(study, cardImageOverride) {
-    const datasetWithImage = study.dataset.filter(ds => ds?.acquisition_process?.length > 0 && ds?.annotation_process?.length == 0).find((dataset) => dataset.example_image_uri.length > 0) ?? study.dataset.filter(ds => ds.example_image_uri.length > 0)[0];
+    const studyImage = study?.example_image_uri?.length > 0? study.example_image_uri: getPlaceholderHeroImage(study.accession_id);
+
     if (cardImageOverride != null) {
       return cardImageOverride
-    } else if (datasetWithImage == undefined || datasetWithImage.example_image_uri[0] === undefined) {
-      return getPlaceholderHeroImage(study.accession_id)
-    } else {
-      return datasetWithImage.example_image_uri[0]
     }
+    return studyImage
 }
 
 export function formatListItem(outputString, item, i, list) {
@@ -72,14 +70,10 @@ export function aggregateDatasetStats(datasets) {
 
 export function getImagingMethodType(study) {
     const imagingTypeList = []
-    for (var dataset of study.dataset) {
-        for (var ia of dataset.acquisition_process) {
-            for (var methodNames of ia.imaging_method_name) {
-                if (!imagingTypeList.includes(methodNames)) {
+    for (var methodNames in study?.imaging_method){
+      if (!imagingTypeList.includes(methodNames)) {
                     imagingTypeList.push(methodNames)
                 }
-            }
-        }
     }
     return imagingTypeList
 }
@@ -87,15 +81,13 @@ export function getImagingMethodType(study) {
 export function getTaxons(study) {
     const taxonHtmlList = []
     const taxonList = []
-    for (var dataset of study.dataset) {
-        for (var biosample of dataset.biological_entity) {
-            for (var taxon of biosample.organism_classification) {
-                if (!taxonList.some(txnFinal => txnFinal.common_name === taxon.common_name || txnFinal.scientific_name === taxon.scientific_name )) {
-                    taxonList.push(taxon)
-                    taxonHtmlList.push(taxonRender(taxon))
-                }
-            }
-        }
+    if (study?.organism_classification){
+      for (var taxon of study?.organism_classification) {
+          if (!taxonList.some(txnFinal => txnFinal.common_name === taxon.common_name || txnFinal.scientific_name === taxon.scientific_name )) {
+              taxonList.push(taxon)
+              taxonHtmlList.push(taxonRender(taxon))
+          }
+      }
     }
     return taxonHtmlList
 }
@@ -156,7 +148,7 @@ export function getAnnotationType(datasets) {
 }
 
 export function getMetadataValue(mdArray, key, field = null) {
-  const md = mdArray.find(md => md.name === key)?.value;
+  const md = mdArray?.find(md => md.name === key)?.value;
   return field && md ? md[field]?.[0] : md;
 }
 
@@ -259,13 +251,13 @@ export async function getFromAPI(url){
 
 export async function getStudyFromApiByUUID(uuid){
     // This can work with dataset uuid or study uuid.
-    const response = await getFromAPI(`${PUBLIC_SEARCH_API}/search/fts?query=${uuid}`);
+    const response = await getFromAPI(`${PUBLIC_SEARCH_API}/website/study?query=${uuid}`);
     const study = response?.hits?.hits?.[0]?._source; 
     return study
 }
 
 export async function getStudyFromApiByAccession(accessionID){
-    const response = await getFromAPI(`${PUBLIC_SEARCH_API}/search/fts?query=${accessionID}`);
+    const response = await getFromAPI(`${PUBLIC_SEARCH_API}/website/study?query=${accessionID}`);
     const study = response?.hits?.hits?.find(
         (hit) => hit._source?.accession_id === accessionID
       )?._source || undefined;
@@ -273,7 +265,7 @@ export async function getStudyFromApiByAccession(accessionID){
 }
 
 export async function getImageFromAPI(uuid){
-    const response = await getFromAPI(`${PUBLIC_SEARCH_API}/search/fts/image?query=${uuid}`);
+    const response = await getFromAPI(`${PUBLIC_SEARCH_API}/website/image?query=${uuid}`);
     const image = response?.hits?.hits?.[0]?._source || null;
     return image
 }
@@ -286,26 +278,46 @@ export async function getImagesFromAPI(uuid_list){
 }
 
 
-export async function getAllStudiesFromAPI(){
-  const firstPage = await getFromAPI(
-      `${PUBLIC_SEARCH_API}/search/fts?query=&pagination.page_size=100`
-    );
-    if (!firstPage) return null;
+async function getAllPaginatedHits(urlBuilder, pageSize = 100) {
+  const firstPage = await getFromAPI(urlBuilder(1, pageSize));
 
-    const totalPages = firstPage.pagination.total_pages;
-    const allHits = [...firstPage.hits.hits];
+  if (!firstPage) return [];
 
-    const otherPages = await Promise.all(
-      Array.from({ length: totalPages - 1 }, (_, i) =>
-        getFromAPI(
-          `${PUBLIC_SEARCH_API}/search/fts?query=&pagination.page_size=100&pagination.page=${i + 2}`,
-          { hits: { hits: [] } }
-        )
-      )
-    );
+  const totalPages = firstPage.pagination?.total_pages ?? 1;
+  const allHits = [...(firstPage.hits?.hits ?? [])];
 
-    otherPages.forEach((p) => allHits.push(...p.hits.hits));
-    return allHits.map((hit) => hit._source);
+  const otherPages = await Promise.all(
+    Array.from({ length: totalPages - 1 }, (_, i) =>
+      getFromAPI(urlBuilder(i + 2, pageSize), { hits: { hits: [] } })
+    )
+  );
+
+  otherPages.forEach((page) => {
+    allHits.push(...(page?.hits?.hits ?? []));
+  });
+
+  return allHits;
+}
+
+export async function getImagesByAccessionID(accessionID) {
+  const hits = await getAllPaginatedHits((page, pageSize) =>
+    `${PUBLIC_SEARCH_API}/website/image` +
+    `?facet.accession_id=${encodeURIComponent(accessionID)}` +
+    `&pagination.page_size=${pageSize}` +
+    `&pagination.page=${page}`
+  );
+
+  return hits.map((hit) => hit._source).filter(Boolean);
+}
+
+export async function getAllStudiesFromAPI() {
+  const hits = await getAllPaginatedHits((page, pageSize) =>
+    `${PUBLIC_SEARCH_API}/website/browse/study` +
+    `?pagination.page_size=${pageSize}` +
+    `&pagination.page=${page}`
+  );
+
+  return hits.map((hit) => hit._source).filter(Boolean);
 }
 
 function isImageAnAnnotation(img){
@@ -327,29 +339,57 @@ export async function getAnnotationFromDerivedImages(sourceImageUUID) {
 }
 
 async function getDerivedImagesFromSourceImage(uuid){
-    const response = await getFromAPI(`${PUBLIC_SEARCH_API}/search/fts/image?query=${uuid}&includeDerivedImages=true`);
+    const response = await getFromAPI(`${PUBLIC_SEARCH_API}/website/image?query=${uuid}&includeDerivedImages=true`);
     const derivedImages = response?.hits?.hits.map(img => img._source).filter(img => img.uuid !== uuid);
     return derivedImages
 }
 
-export async function generateSourceAnnotatedImageMap(study){
-    const annotatedImagesMap = new Map();
-    const skipImageUUID = ["2a382f3a-aa6d-4ace-99fb-468335fa3809", "8921dcfb-4f5b-4ac1-a390-04b3ef2155ea", "d0b3f24f-4a9c-499b-99e4-343de48e7c82"]
-    const imagesFromStudies = study?.dataset?.flatMap(ds => ds.image).filter(img => !skipImageUUID.includes(img.uuid)) || [];
-    const images = await Promise.all(imagesFromStudies.map(async (image) => await getImageFromAPI(image.uuid)));
-    for (const img of Object.values(images)) {
-        if (isImageAnAnnotation(img)) {
-            const key = img.creation_process.input_image_uuid[0];
-            if (skipImageUUID.includes(key)) {
-              continue;
-            }
-            if (!annotatedImagesMap.has(key)) {
-                annotatedImagesMap.set(key, []);
-            }
-            annotatedImagesMap.get(key).push(img);
-        }
+export async function generateSourceAnnotatedImageMap(accession_id) {
+  const annotatedImagesMap = new Map();
+
+  const skipImageUUID = [
+    "2a382f3a-aa6d-4ace-99fb-468335fa3809",
+    "8921dcfb-4f5b-4ac1-a390-04b3ef2155ea",
+    "d0b3f24f-4a9c-499b-99e4-343de48e7c82",
+  ];
+
+  const images = await getImagesByAccessionID(accession_id);
+
+  const sourceImagesByUuid = new Map(
+    images
+      .filter(img => img && !isImageAnAnnotation(img))
+      .filter(img => !skipImageUUID.includes(img.uuid))
+      .map(img => [img.uuid, img])
+  );
+
+  for (const img of images) {
+    if (!img || !isImageAnAnnotation(img)) {
+      continue;
     }
-    return annotatedImagesMap
+
+    const sourceImageUuid = img.creation_process?.input_image_uuid?.[0];
+
+    if (!sourceImageUuid || skipImageUUID.includes(sourceImageUuid)) {
+      continue;
+    }
+
+    const sourceImage = sourceImagesByUuid.get(sourceImageUuid);
+
+    if (!sourceImage) {
+      continue;
+    }
+
+    if (!annotatedImagesMap.has(sourceImageUuid)) {
+      annotatedImagesMap.set(sourceImageUuid, {
+        sourceImage,
+        annotationImages: [],
+      });
+    }
+
+    annotatedImagesMap.get(sourceImageUuid).annotationImages.push(img);
+  }
+
+  return annotatedImagesMap;
 }
 
 export function getTutorialURLs(urlType){

--- a/src/components/SharedJSFunctions.js
+++ b/src/components/SharedJSFunctions.js
@@ -55,7 +55,14 @@ export function getSimpleAttributeValue(obj, attrName) {
       ?.value[attrName] ?? null;
 }
   
-  
+export function getLicenceLogo(licenceURL){
+    const licenceImage = licenceURL.split("/").slice(-3)[0]
+    const isCreativeCommons = licenceURL.includes("creativecommons");
+    var logoURL = isCreativeCommons? "http://mirrors.creativecommons.org/presskit/buttons/88x31/svg/": "";
+    logoURL += licenceImage === "zero"? "cc-zero.svg": `${licenceImage}.svg`;
+    return logoURL
+
+}  
 export function getDatasetStatsByUUID(study) {
     return aggregateDatasetStats(study?.dataset || []);
 }

--- a/src/components/TrainingSection.astro
+++ b/src/components/TrainingSection.astro
@@ -18,11 +18,11 @@
   <div class="vf-tabs-content" data-vf-js-tabs-content>
     <section class="vf-tabs__section" id="vf-tabs__section--1">
       <div id="live-tutorials"></div>
-      <a href="https://www.ebi.ac.uk/training/services/bioimage-archive/live-events" class="vf-link">View all live training</a>
+      <a href="https://www.ebi.ac.uk/training/services/bioimage-archive/live-events" class="vf-link" target="_blank">View all live training</a>
     </section>
     <section class="vf-tabs__section" id="vf-tabs__section--2">
       <div id="ondemand-tutorials"></div>
-      <a href="https://www.ebi.ac.uk/training/services/bioimage-archive/on-demand" class="vf-link">View all on-demand training</a>
+      <a href="https://www.ebi.ac.uk/training/services/bioimage-archive/on-demand" class="vf-link" target="_blank">View all on-demand training</a>
     </section>
   </div>
 </div>
@@ -40,13 +40,12 @@
         try {
         const res = await fetch(url);
         const data = await res.json();
-
         const container = document.getElementById(containerId);
         container.innerHTML = "";
 
         const tutorials = data.entries || data;
         if(tutorials.length == 0){
-            container.innerHTML = "No courses found";
+            container.innerHTML = "<p>Currently there are no upcoming events - please click the below link for more information</p>";
         }
         tutorials.forEach((item) => {
             const html = `

--- a/src/components/ViewableImageTable.astro
+++ b/src/components/ViewableImageTable.astro
@@ -1,5 +1,6 @@
 ---
-import ImageRow from "./ImageTableRow.astro"
+import imageFallback from "../assets/bioimage-archive/image_fallback.png";
+import { PUBLIC_SEARCH_API } from "astro:env/client";
 const { study, images, imagePageRoot } = Astro.props;
 
 ---
@@ -24,23 +25,9 @@ const { study, images, imagePageRoot } = Astro.props;
           </tr>
         </thead>
         <tbody>
-          {
-            images.map((image) => (
-              <ImageRow image={image} datasetTitle={study.dataset.find((dataset) => dataset.uuid === image.submission_dataset_uuid).title} imagePageRoot={imagePageRoot}/>
-            ))
-          }
         </tbody>
       </table>
     </div>
-    <script>
-      document.addEventListener("DOMContentLoaded", function () {
-              $("#viewable_images_table").DataTable({
-                scrollX: true,
-                columnDefs: [{ type: "natural", targets: 0 }],
-              });
-            });
-
-    </script>
     ): (
       <div>
         <p>
@@ -56,3 +43,189 @@ const { study, images, imagePageRoot } = Astro.props;
   overflow-wrap: anywhere;
 }
 </style>
+
+<script define:vars={{
+  studyAccessionID: study.accession_id,
+  imagePageRoot,
+  imageFallbackSrc: imageFallback.src,
+  api_path: PUBLIC_SEARCH_API
+}}>
+  function imageUrl(image) {
+    return imagePageRoot
+      ? `/bioimage-archive/${imagePageRoot}/${image.uuid}`
+      : `/bioimage-archive/image/${image.uuid}`;
+  }
+
+  function getMetadataValue(mdArray, key, field = null) {
+    const md = mdArray?.find(md => md.name === key)?.value;
+    return field && md ? md[field]?.[0] : md;
+  }
+
+  function getThumbnail(img) {
+      const thumbnail_uri = getMetadataValue(img.additional_metadata, "image_thumbnail_uri")?.["256"]?.["uri"] || imageFallbackSrc;
+      return thumbnail_uri;
+  }
+  function getDownloadSize(image) {
+    const file_size = image?.total_size_in_bytes > 0? image.total_size_in_bytes : "Unkown"
+    return file_size
+  }
+  function escapeHtml(value) {
+    return String(value ?? "")
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#039;");
+  }
+
+  function normaliseFilePaths(image) {
+    const value = image.label || image.file_path || "";
+
+    if (Array.isArray(value)) {
+      return value.filter(Boolean);
+    }
+
+    return [value].filter(Boolean);
+  }
+
+  function formatFilePath(path, every = 40) {
+    return (
+      escapeHtml(path)
+        .match(new RegExp(`.{1,${every}}`, "g"))
+        ?.join("<wbr>") || ""
+    );
+  }
+
+  function renderFilePaths(image) {
+    const paths = normaliseFilePaths(image);
+
+    if (paths.length === 0) return "";
+
+    const visible = paths.slice(0, 2);
+    const hidden = paths.slice(2);
+
+    const renderPath = (path, index, arr) => `
+      <div>
+        ${formatFilePath(path)}${index < arr.length - 1 ? "," : ""}
+      </div>
+    `;
+
+    const visibleHtml = visible
+      .map((path, index) => `
+        <div>
+          ${formatFilePath(path)}${index < paths.length - 1 ? "," : ""}
+        </div>
+      `)
+      .join("");
+
+    if (hidden.length === 0) {
+      return `<span class="file-path">${visibleHtml}</span>`;
+    }
+
+    const hiddenHtml = hidden
+      .map((path, index) => `
+        <div>
+          ${formatFilePath(path)}${index + visible.length < paths.length - 1 ? "," : ""}
+        </div>
+      `)
+      .join("");
+
+    return `
+      <span class="file-path">
+        ${visibleHtml}
+        <span class="file-path-extra" style="display:none;">
+          ${hiddenHtml}
+        </span>
+        <button type="button" class="file-path-toggle vf-button vf-button--link">
+          Expand
+        </button>
+      </span>
+    `;
+  }
+  document.addEventListener("click", function (event) {
+    const button = event.target.closest(".file-path-toggle");
+    if (!button) return;
+
+    const wrapper = button.closest(".file-path");
+    const extra = wrapper.querySelector(".file-path-extra");
+
+    const isHidden = extra.style.display === "none";
+
+    extra.style.display = isHidden ? "inline" : "none";
+    button.textContent = isHidden ? "Collapse" : "Expand";
+  });
+
+  document.addEventListener("DOMContentLoaded", function () {
+    if ($.fn.DataTable.isDataTable("#viewable_images_table")) {
+      $("#viewable_images_table").DataTable().destroy();
+    }
+
+    $("#viewable_images_table").DataTable({
+      processing: true,
+      serverSide: true,
+      searching: true,
+      ordering: false,
+      scrollX: true,
+      searchDelay: 800,
+      pageLength: 10,
+
+      ajax: async function (dtParams, callback) {
+        const search = dtParams.search.value;
+        const pageSize = dtParams.length;
+        const page = Math.floor(dtParams.start / pageSize) + 1;
+        const url =
+          `${api_path}/website/browse/image` +
+          `?facet.accession_id=${encodeURIComponent(studyAccessionID)}` +
+          `&query=${encodeURIComponent(search)}` +
+          `&pagination.page_size=${pageSize}` +
+          `&pagination.page=${page}`;
+        const res = await fetch(url);
+        const json = await res.json();
+
+        const images = (json.hits?.hits || []).map((hit) => hit._source);
+
+        const total =
+          json.hits?.total?.value ||
+          json.pagination?.total_results ||
+          images.length;
+
+        callback({
+          draw: dtParams.draw,
+          recordsTotal: total,
+          recordsFiltered: total,
+          data: images,
+        });
+      },
+
+      columns: [
+        {
+          data: "preview",
+          render: (_d, _t, image) => `
+            <a href="${imageUrl(image)}">
+              <img class="vf-figure__image" src="${getThumbnail(image) || ""}" />
+            </a>
+          `,
+        },
+        { data: "uuid", defaultContent: "" },
+        {
+          data: "file_path",
+          render: (_d, _t, image) => { return renderFilePaths(image); }
+        },
+        {
+          data: "dataset",
+          render: (_d, _t, image) =>
+            image.dataset_title || "",
+        },
+        {
+          data: "total_size_in_bytes",
+          render: (_d, _t, image) => getDownloadSize(image),
+        },
+        {
+          data: "actions",
+          render: (_d, _t, image) =>
+            `<a class="vf-link" href="${imageUrl(image)}">View</a>`,
+        },
+      ],
+    });
+  });
+</script>

--- a/src/components/ViewableImageTable.astro
+++ b/src/components/ViewableImageTable.astro
@@ -67,8 +67,8 @@ const { study, images, imagePageRoot } = Astro.props;
       return thumbnail_uri;
   }
   function getDownloadSize(image) {
-    const file_size = image?.total_size_in_bytes > 0? image.total_size_in_bytes : "Unkown"
-    return file_size
+    var i = image?.total_size_in_bytes == 0 ? 0 : Math.floor(Math.log(image?.total_size_in_bytes) / Math.log(1000));
+    return `${Number(image?.total_size_in_bytes / Math.pow(1000, i)).toFixed(2)} ${['B', 'kB', 'MB', 'GB', 'TB', 'PB'][i]}`
   }
   function escapeHtml(value) {
     return String(value ?? "")
@@ -104,12 +104,6 @@ const { study, images, imagePageRoot } = Astro.props;
 
     const visible = paths.slice(0, 2);
     const hidden = paths.slice(2);
-
-    const renderPath = (path, index, arr) => `
-      <div>
-        ${formatFilePath(path)}${index < arr.length - 1 ? "," : ""}
-      </div>
-    `;
 
     const visibleHtml = visible
       .map((path, index) => `

--- a/src/components/ViewableImageTable.astro
+++ b/src/components/ViewableImageTable.astro
@@ -1,6 +1,7 @@
 ---
 import imageFallback from "../assets/bioimage-archive/image_fallback.png";
 import { PUBLIC_SEARCH_API } from "astro:env/client";
+const SEARCH_API = PUBLIC_SEARCH_API === "http://localhost:8081/v1" || PUBLIC_SEARCH_API.includes("alpha.bioimage")? PUBLIC_SEARCH_API: "/search/v1";
 const { study, images, imagePageRoot } = Astro.props;
 
 ---
@@ -48,7 +49,7 @@ const { study, images, imagePageRoot } = Astro.props;
   studyAccessionID: study.accession_id,
   imagePageRoot,
   imageFallbackSrc: imageFallback.src,
-  api_path: PUBLIC_SEARCH_API
+  api_path: SEARCH_API
 }}>
   function imageUrl(image) {
     return imagePageRoot

--- a/src/components/ai-benchmarking/BenchmarkedDatasetPage.astro
+++ b/src/components/ai-benchmarking/BenchmarkedDatasetPage.astro
@@ -83,7 +83,7 @@ const exampleAnnotationURI = studyAIInfo.hero_image_gt
 
     <div style="overflow-wrap: anywhere;">
       <div><b>Description: </b> <Fragment set:html={multilineTextRender(study.description)}/></div>
-      <div><b>Licence: </b> <a href={study.licence}>{study.licence}</a><div>
+      <div><b>Licence: </b> <a href={study.licence_details.uri}>{study.licence_details.label}</a><div>
       {
         studyAIInfo.tags && (
           <div><b>Tags:</b> {studyAIInfo.tags.reduce(formatListItem, "")}</div>

--- a/src/components/cards/BrowseImageCard.astro
+++ b/src/components/cards/BrowseImageCard.astro
@@ -1,54 +1,24 @@
 ---
-import { formatListItem, getThumbnail, getSimpleAttributeValue, formatPhysicalDimensions, formatPixelDimensions, applyHighlight, highlightLinks, getLicenceLogo } from "../SharedJSFunctions.js";
+import { highlightOrganism, formatListItem, getThumbnail, getSimpleAttributeValue, formatPhysicalDimensions, formatPixelDimensions, applyHighlight, highlightLinks, getLicenceLogo, formatHighlightedList } from "../SharedJSFunctions.js";
 import "../../styles/dataset_card.css"
 import  HighlightedText  from "../HighlightedText.astro";
-import { highlightImagingMethod } from "./BrowseStudyCard.astro"
 import imageFallback from "../../assets/bioimage-archive/image_fallback.png"
 
-const { image, imagePageRoot, taglist, annotationType, highlight, cardImageOverride, query} = Astro.props;
-
-export function highlightOrganism(text, highlight, query){
-    const highlightOrganism = highlight?.['creation_process.subject.sample_of.organism_classification.common_name']?.[0] || highlight?.['creation_process.subject.sample_of.organism_classification.scientific_name']?.[0];
-    return query && text? applyHighlight(text, highlightOrganism, query): text;
-
-}
-
-export function highlightImageFormat(text, highlight, query){
-
-}
+const { image, imagePageRoot, taglist, annotationType, highlight, query} = Astro.props;
 
 const vizarrRepUuid = getSimpleAttributeValue(image, "recommended_vizarr_representation");
 const interactiveImageRepresentation = (image.representation.find(
     (rep) => rep.uuid == vizarrRepUuid
 ) ?? image.representation.find( (rep) => rep.image_format === ".ome.zarr") )
 
-type Taxon = {
-  scientific_name?: string;
-  common_name?: string;
-};
-const taxons: Taxon[] = [
-  ...new Map(
-    (image?.organism_classification ?? [])
-      .filter(Boolean)
-      .map((t: Taxon) => [
-        t.scientific_name || t.common_name,
-        {
-          scientific_name: t.scientific_name,
-          common_name: t.common_name,
-        },
-      ])
-  ).values(),
-];
-const taxonNames = taxons.map(t =>
-  t?.common_name ? `${t?.scientific_name} (${t?.common_name})` : t?.scientific_name
-);
+const organism = highlightOrganism(image, query);
 
-const imagingMethod = [
-  ...new Set(
-    (image?.imaging_method ?? [])
-      .filter(Boolean).sort()
-  )
-];
+const imagingMethod = formatHighlightedList(image?.imaging_method, query, {
+  sort: false,
+});
+const annotationMethod = formatHighlightedList(annotationType ?? image?.annotation_type?.map((at: string) => at.replace(/_/g, " ")) ?? [], query, {
+  sort: false,
+})
 
 const imageFormat = [
   ...new Set(
@@ -57,7 +27,7 @@ const imageFormat = [
       .filter(Boolean).sort()
   )
 ];
-const highLightedImageFormat = imageFormat.flatMap(imf=> query && imf? applyHighlight(imf, highlight?.["representation.image_format"]?.[0], query): imf)
+const highLightedImageFormat = imageFormat.flatMap(imf=> query && imf? applyHighlight(imf, query): imf)
 
 const accessionId = image?.accession_id || "";
 
@@ -80,8 +50,9 @@ const showSizeBar = hasPhysical || hasPixel;
 const thumbnail_uri =  getThumbnail(image);
 const isFallback = thumbnail_uri === imageFallback.src;
 const fallbackMessage = isFallback ? "Preview not available yet." : "";
-const licenceURL = image?.licence;
-const logoURL = getLicenceLogo(licenceURL);
+const licenceURL = image?.licence_details?.uri || image?.licence;
+const logoURL = image?.licence_details?.logo_uri || getLicenceLogo(licenceURL);
+const logoAlt = image?.licence_details?.label || "";
 const base = `/bioimage-archive/${imagePageRoot}/${image.uuid}`;
 const highlightedImageLink = highlightLinks(base, highlight, query);
 ---
@@ -119,15 +90,15 @@ const highlightedImageLink = highlightLinks(base, highlight, query);
         </div>
         <div class="license-badge">
             {licenceURL && logoURL && (
-                <a href={licenceURL} class="vf-link"><img src={logoURL}/></a>
+                <a href={licenceURL} class="vf-link"><img src={logoURL} alt={logoAlt}/></a>
             )}
 
         </div>
     </div>
     <div class="vf-card__content">
         <p class="vf-card__text">
-            {imagingMethod.length>0 && (<b>Imaging method: </b><HighlightedText text={imagingMethod.flatMap(im=> highlightImagingMethod(im, highlight?.["creation_process.acquisition_process.imaging_method_name"], query)).join(", ")} /><br>)}
-            {taxonNames.length>0 && (<b>Organism: </b><HighlightedText text={taxonNames.map(taxon => highlightOrganism(taxon, highlight, query)).join(", ")} /><br>)}
+            {imagingMethod.length>0 && (<b>Imaging method: </b><HighlightedText text={imagingMethod} /><br>)}
+            {organism && (<b>Organism: </b><HighlightedText text={organism} /><br>)}
             <b>Image format: </b><HighlightedText text={highLightedImageFormat.join(", ")} /><br>
             {interactiveImageRepresentation?.size_c && (<><b>Number of channels:</b> {interactiveImageRepresentation?.size_c}<br /></>)}
             {interactiveImageRepresentation?.size_t && (<><b>Number of timesteps:</b> {interactiveImageRepresentation?.size_t}</>)}
@@ -139,9 +110,9 @@ const highlightedImageLink = highlightLinks(base, highlight, query);
             </p>
         )}
 
-        {annotationType && annotationType.length > 0 && (
+        {annotationMethod && annotationMethod.length > 0 && (
             <p class="vf-card__text">
-                <b>Annotation Type:</b> {annotationType.join(", ") || "No information available"}
+                <b>Annotation Type:</b> <HighlightedText text={annotationMethod || "No information available"} />
             </p>
         )}
         <h3 class="vf-card__heading"><a class="vf-card__link" href={highlight? highlightedImageLink : base} ></a></h3>

--- a/src/components/cards/BrowseImageCard.astro
+++ b/src/components/cards/BrowseImageCard.astro
@@ -28,14 +28,16 @@ type Taxon = {
 };
 const taxons: Taxon[] = [
   ...new Map(
-    (image?.creation_process?.subject?.sample_of ?? [])
-      .flatMap(s => s?.organism_classification ?? [])
+    (image?.organism_classification ?? [])
       .filter(Boolean)
       .map((t: Taxon) => [
         t.scientific_name || t.common_name,
-        { scientific_name: t.scientific_name, common_name: t.common_name }
+        {
+          scientific_name: t.scientific_name,
+          common_name: t.common_name,
+        },
       ])
-  ).values()
+  ).values(),
 ];
 const taxonNames = taxons.map(t =>
   t?.common_name ? `${t?.scientific_name} (${t?.common_name})` : t?.scientific_name
@@ -43,8 +45,7 @@ const taxonNames = taxons.map(t =>
 
 const imagingMethod = [
   ...new Set(
-    (image?.creation_process?.acquisition_process ?? [])
-      .flatMap(ap => ap?.imaging_method_name ?? [])
+    (image?.imaging_method ?? [])
       .filter(Boolean).sort()
   )
 ];
@@ -117,8 +118,8 @@ const highlightedImageLink = highlightLinks(base, highlight, query);
     </div>
     <div class="vf-card__content">
         <p class="vf-card__text">
-            <b>Imaging method: </b><HighlightedText text={imagingMethod.flatMap(im=> highlightImagingMethod(im, highlight?.["creation_process.acquisition_process.imaging_method_name"], query)).join(", ")} /><br>
-            <b>Organism: </b><HighlightedText text={taxonNames.map(taxon => highlightOrganism(taxon, highlight, query)).join(", ")} /><br>
+            {imagingMethod.length>0 && (<b>Imaging method: </b><HighlightedText text={imagingMethod.flatMap(im=> highlightImagingMethod(im, highlight?.["creation_process.acquisition_process.imaging_method_name"], query)).join(", ")} /><br>)}
+            {taxonNames.length>0 && (<b>Organism: </b><HighlightedText text={taxonNames.map(taxon => highlightOrganism(taxon, highlight, query)).join(", ")} /><br>)}
             <b>Image format: </b><HighlightedText text={highLightedImageFormat.join(", ")} /><br>
             {interactiveImageRepresentation?.size_c && (<><b>Number of channels:</b> {interactiveImageRepresentation?.size_c}<br /></>)}
             {interactiveImageRepresentation?.size_t && (<><b>Number of timesteps:</b> {interactiveImageRepresentation?.size_t}</>)}

--- a/src/components/cards/BrowseImageCard.astro
+++ b/src/components/cards/BrowseImageCard.astro
@@ -1,5 +1,5 @@
 ---
-import { formatListItem, getThumbnail, getSimpleAttributeValue, formatPhysicalDimensions, formatPixelDimensions, applyHighlight, highlightLinks } from "../SharedJSFunctions.js";
+import { formatListItem, getThumbnail, getSimpleAttributeValue, formatPhysicalDimensions, formatPixelDimensions, applyHighlight, highlightLinks, getLicenceLogo } from "../SharedJSFunctions.js";
 import "../../styles/dataset_card.css"
 import  HighlightedText  from "../HighlightedText.astro";
 import { highlightImagingMethod } from "./BrowseStudyCard.astro"
@@ -80,6 +80,8 @@ const showSizeBar = hasPhysical || hasPixel;
 const thumbnail_uri =  getThumbnail(image);
 const isFallback = thumbnail_uri === imageFallback.src;
 const fallbackMessage = isFallback ? "Preview not available yet." : "";
+const licenceURL = image?.licence;
+const logoURL = getLicenceLogo(licenceURL);
 const base = `/bioimage-archive/${imagePageRoot}/${image.uuid}`;
 const highlightedImageLink = highlightLinks(base, highlight, query);
 ---
@@ -114,6 +116,12 @@ const highlightedImageLink = highlightLinks(base, highlight, query);
         }   
         <div class="study-link">
             { accessionId }
+        </div>
+        <div class="license-badge">
+            {licenceURL && logoURL && (
+                <a href={licenceURL} class="vf-link"><img src={logoURL}/></a>
+            )}
+
         </div>
     </div>
     <div class="vf-card__content">
@@ -221,8 +229,8 @@ const highlightedImageLink = highlightLinks(base, highlight, query);
 
     .study-link {
         position: absolute;
-        top: 10px;
-        right: 10px;
+        top: 7px;
+        right: 7px;
         background: rgba(243, 243, 243, 0.9);
         padding: 4px 8px;
         border-radius: 4px;
@@ -237,14 +245,15 @@ const highlightedImageLink = highlightLinks(base, highlight, query);
     }
     .license-badge {
         position: absolute;
-        top: 45px;
-        right: 10px;
+        top: 7px;
+        left: 7px;
         background: rgba(243, 243, 243, 0.9);
-        padding: 2px;
-        border-radius: 4px;
+        padding: 0px;
+        z-index: 999;
     }
     .license-badge img {
-        height: var(--license-badge-height, 20px);
+        display: block;
+        height: var(--license-badge-height, 28px);
         width: auto;
     }
     .image-overlay {
@@ -259,6 +268,5 @@ const highlightedImageLink = highlightLinks(base, highlight, query);
         padding: 12px;
         opacity: 1;
         pointer-events: none;
-        z-index: 999;
     }
 </style>

--- a/src/components/cards/BrowseStudyCard.astro
+++ b/src/components/cards/BrowseStudyCard.astro
@@ -1,5 +1,5 @@
 ---
-import { getTaxons, formatListItem, getStudyImage, getImagingMethodType, applyHighlight, highlightLinks } from "../SharedJSFunctions.js";
+import { getTaxons, formatListItem, getStudyImage, getImagingMethodType, applyHighlight, highlightLinks, getLicenceLogo } from "../SharedJSFunctions.js";
 import  HighlightedText  from "../HighlightedText.astro";
 import "../../styles/dataset_card.css"
 import { fade } from "astro:transitions";
@@ -59,6 +59,10 @@ const organism = highlightOrganism(renderTaxonList(study), highlight, query);
 const annotationMethod = annotationType? annotationType: getAnnotationMethod(study);
 const highlightedAnnotationMethod = highlightImagingMethod(annotationMethod.join(", "), highlight?.["dataset.annotation_process.method_type"], query)
 
+const licenceURL = study?.licence;
+const logoURL = getLicenceLogo(licenceURL);
+
+
 const base = `/bioimage-archive/${studyPageRoot}/${study.accession_id}`;
 const highlightedStudyLink = highlightLinks(base, highlight, query);
 ---
@@ -70,6 +74,11 @@ const highlightedStudyLink = highlightLinks(base, highlight, query);
                     <span>{fallbackMessage}</span>
                 </div>
             )}
+        <div class="license-badge">
+            {licenceURL && logoURL && (
+                <a href={licenceURL} class="vf-link"><img src={logoURL}/></a>
+            )}
+        </div>
     </div>
     <div class="vf-card__content | vf-stack vf-stack--400">
         <h3 class="vf-card__heading">
@@ -119,5 +128,18 @@ const highlightedStudyLink = highlightLinks(base, highlight, query);
         overflow: hidden;
         position: relative;
     }
-
+    .license-badge {
+        position: absolute;
+        top: 7px;
+        left: 7px;
+        background: rgba(243, 243, 243, 0.9);
+        padding: 0px;
+        border-radius: 4px;
+        z-index: 999;
+    }
+    .license-badge img {
+        display: block;
+        height: var(--license-badge-height, 28px);
+        width: auto;
+    }
 </style>

--- a/src/components/cards/BrowseStudyCard.astro
+++ b/src/components/cards/BrowseStudyCard.astro
@@ -2,10 +2,11 @@
 import { getTaxons, formatListItem, getStudyImage, getImagingMethodType, applyHighlight, highlightLinks } from "../SharedJSFunctions.js";
 import  HighlightedText  from "../HighlightedText.astro";
 import "../../styles/dataset_card.css"
+import { fade } from "astro:transitions";
 const { study, studyPageRoot, taglist, annotationType, cardImageOverride, highlight, query} = Astro.props;
 
 export function getImagingType(study) {
-    const imageTypeList = getImagingMethodType(study)
+    const imageTypeList = study?.imaging_method || []//getImagingMethodType(study)
     const imgTypeDisplay = imageTypeList.reduce(formatListItem, "")
     if (imgTypeDisplay.length > 50 * imageTypeList.length) {
         // Avoid displaying full method text on dataset cards.
@@ -17,11 +18,9 @@ export function getImagingType(study) {
 
 export function getAnnotationMethod(study){
     const annotationMethods = new Set();
-    for (var dataset of study.dataset) {
-        for (var ap of dataset.annotation_process) {
-            for (var methodNames of ap.method_type) {
-                annotationMethods.add(methodNames.replace(/_/g, " "))
-            }
+    if (study.annotation_type != null){
+        for (var methodNames of study.annotation_type) {
+            annotationMethods.add(methodNames.replace(/_/g, " "))
         }
     }
     return [...annotationMethods]
@@ -34,8 +33,7 @@ export function renderTaxonList(dataset) {
 }
 
 function getDataForCardFilter(study) {
-    const datasetWithImage = study.dataset.find((dataset) => dataset.image?.length > 0)
-    var hasImage = datasetWithImage !== undefined
+    var hasImage = study?.image?.length > 0 || false;
     const dataString = `${study.accession_id}; ${study.release_date}; ${study.title}; ${renderTaxonList(study)}; ${getImagingType(study)}; has_img: ${hasImage}`
     return dataString
 }

--- a/src/components/cards/BrowseStudyCard.astro
+++ b/src/components/cards/BrowseStudyCard.astro
@@ -1,67 +1,28 @@
 ---
-import { getTaxons, formatListItem, getStudyImage, getImagingMethodType, applyHighlight, highlightLinks, getLicenceLogo } from "../SharedJSFunctions.js";
+import { highlightOrganism, renderTaxonList, formatListItem, getStudyImage, highlightLinks, getLicenceLogo, formatHighlightedList } from "../SharedJSFunctions.js";
 import  HighlightedText  from "../HighlightedText.astro";
 import "../../styles/dataset_card.css"
-import { fade } from "astro:transitions";
 const { study, studyPageRoot, taglist, annotationType, cardImageOverride, highlight, query} = Astro.props;
-
-export function getImagingType(study) {
-    const imageTypeList = study?.imaging_method || []//getImagingMethodType(study)
-    const imgTypeDisplay = imageTypeList.reduce(formatListItem, "")
-    if (imgTypeDisplay.length > 50 * imageTypeList.length) {
-        // Avoid displaying full method text on dataset cards.
-        return 'See details of study'
-    } else {
-        return imgTypeDisplay
-    }
-}
-
-export function getAnnotationMethod(study){
-    const annotationMethods = new Set();
-    if (study.annotation_type != null){
-        for (var methodNames of study.annotation_type) {
-            annotationMethods.add(methodNames.replace(/_/g, " "))
-        }
-    }
-    return [...annotationMethods]
-
-}
-
-export function renderTaxonList(dataset) {
-    const taxonList = getTaxons(dataset)
-    return taxonList.reduce(formatListItem, "")
-}
 
 function getDataForCardFilter(study) {
     var hasImage = study?.image?.length > 0 || false;
-    const dataString = `${study.accession_id}; ${study.release_date}; ${study.title}; ${renderTaxonList(study)}; ${getImagingType(study)}; has_img: ${hasImage}`
+    const dataString = `${study.accession_id}; ${study.release_date}; ${study.title}; ${renderTaxonList(study)}; ${study?.imaging_method?.reduce(formatListItem, "")}; has_img: ${hasImage}`
     return dataString
-}
-
-export function highlightImagingMethod(text, highlight, query){
-    const highlightedImagingMethod = [...new Set(highlight)];
-    const highlightedText = highlightedImagingMethod.map(highlight => applyHighlight(text, highlight, query))
-    return query && highlightedImagingMethod.length > 0?[...new Set(highlightedText)]: text;
-
-}
-
-export function highlightOrganism(text, highlight, query){
-    const highlightOrganism = highlight?.['dataset.biological_entity.organism_classification.common_name']?.[0] || highlight?.['dataset.biological_entity.organism_classification.scientific_name']?.[0];
-    return query && text? applyHighlight(text, highlightOrganism, query): text;
-
 }
 
 const studyCardImage = getStudyImage(study, cardImageOverride);
 const isFallback = String(studyCardImage).includes("placeholder");
 const fallbackMessage = isFallback ? "We cannot display images for this study yet." : "";
-const imagingMethod = highlightImagingMethod(getImagingType(study), highlight?.["dataset.acquisition_process.imaging_method_name"], query);
-const organism = highlightOrganism(renderTaxonList(study), highlight, query);
-const annotationMethod = annotationType? annotationType: getAnnotationMethod(study);
-const highlightedAnnotationMethod = highlightImagingMethod(annotationMethod.join(", "), highlight?.["dataset.annotation_process.method_type"], query)
-
-const licenceURL = study?.licence;
-const logoURL = getLicenceLogo(licenceURL);
-
+const imagingMethod = formatHighlightedList(study?.imaging_method, query, {
+  sort: false,
+});
+const organism = highlightOrganism(study, query);
+const annotationMethod = formatHighlightedList(annotationType ?? study?.annotation_type?.map((at: string) => at.replace(/_/g, " ")) ?? [], query, {
+  sort: false,
+});
+const licenceURL = study?.licence_details?.uri || study?.licence;
+const logoURL = study?.licence_details?.logo_uri || getLicenceLogo(licenceURL);
+const logoAlt = study?.licence_details?.label || "";
 
 const base = `/bioimage-archive/${studyPageRoot}/${study.accession_id}`;
 const highlightedStudyLink = highlightLinks(base, highlight, query);
@@ -76,7 +37,7 @@ const highlightedStudyLink = highlightLinks(base, highlight, query);
             )}
         <div class="license-badge">
             {licenceURL && logoURL && (
-                <a href={licenceURL} class="vf-link"><img src={logoURL}/></a>
+                <a href={licenceURL} class="vf-link"><img src={logoURL} alt={logoAlt}/></a>
             )}
         </div>
     </div>
@@ -102,7 +63,7 @@ const highlightedStudyLink = highlightLinks(base, highlight, query);
 
         {annotationMethod && annotationMethod.length > 0 && (
             <p class="vf-card__text">
-                <b>Annotation Method:</b><HighlightedText text={highlightedAnnotationMethod || "No information available"} />
+                <b>Annotation Method:</b><HighlightedText text={annotationMethod || "No information available"} />
             </p>
         )}
     </div>

--- a/src/components/cards/VolumeEMImageCard.astro
+++ b/src/components/cards/VolumeEMImageCard.astro
@@ -181,6 +181,7 @@ const rawDataLink = accessionID.startsWith("S-BIAD")
         border-radius: 4px;
     }
     .license-badge img {
+        display: block;
         height: var(--license-badge-height, 20px);
         width: auto;
     }

--- a/src/components/search/Search.astro
+++ b/src/components/search/Search.astro
@@ -20,7 +20,7 @@ const { url, query, searchType} =
     searchType: string;
   };
 
-const searchEndpoint = searchType === "study"? `${PUBLIC_SEARCH_API}/search/fts`: `${PUBLIC_SEARCH_API}/search/fts/image`;
+const searchEndpoint = searchType === "study"? `${PUBLIC_SEARCH_API}/website/browse/study`: `${PUBLIC_SEARCH_API}/website/browse/image`;
 const searchPageURL = searchType === "study"? "/bioimage-archive/studies": "/bioimage-archive/images";
 const sortBy = url.searchParams.get('sortBy');
 const sortOrder = url.searchParams.get('sortOrder');

--- a/src/components/search/Search.astro
+++ b/src/components/search/Search.astro
@@ -22,8 +22,8 @@ const { url, query, searchType} =
 
 const searchEndpoint = searchType === "study"? `${PUBLIC_SEARCH_API}/website/browse/study`: `${PUBLIC_SEARCH_API}/website/browse/image`;
 const searchPageURL = searchType === "study"? "/bioimage-archive/studies": "/bioimage-archive/images";
-const sortBy = url.searchParams.get('sortBy');
-const sortOrder = url.searchParams.get('sortOrder');
+//const sortBy = url.searchParams.get('sortBy');
+//const sortOrder = url.searchParams.get('sortOrder');
 const page = Number(url.searchParams.get('pagination.page')) || 1;
 const pageSize = Number(url.searchParams.get('pagination.page_size')) || 12;
 
@@ -34,6 +34,7 @@ const selectedFacets: SelectedFacets = {
   "facet.annotation_method": url.searchParams.getAll("facet.annotation_method"),
   "has_converted_image": url.searchParams.getAll("has_converted_image"),
   "facet.image_format": url.searchParams.getAll("facet.image_format"),
+  "facet.licence": url.searchParams.getAll("facet.licence"),
   "size_c.eq": url.searchParams.getAll("size_c.eq"),
 
   // NEW: range filters (store as single-value arrays for compatibility)
@@ -81,6 +82,7 @@ const FACET_CONFIG: Record<
   annotation_method: { title: "Annotation Method", type: "terms", queryKey: "facet.annotation_method" },
   image_format: { title: "Image Format", type: "terms", queryKey: "facet.image_format" },
   number_of_channels: { title: "Channels", type: "terms", queryKey: "size_c.eq" },
+  licence: {title: "Licence", type:"terms", queryKey: "facet.licence"},
 
   z_planes: { title: "Z-Planes", type: "slider", field: "size_z" },
   image_pixel_x: { title: "Image Pixel X (px)", type: "slider", field: "size_x" },
@@ -120,10 +122,12 @@ if (hasQueryParam) {
 
 
 const totalResults = hits?.total?.value ?? 0;
-let results;
+let results = hits.hits;
 
 // Sorting on Server side till the API can sort results.
 
+/*
+Commenting it out as Sort is not ready on the API and we dont use it on FE for now
 function parseAccession(id) {
     const match = id.match(/^([A-Z\-]+)(\d+)$/i);
     if (!match) return [id, 0];
@@ -158,6 +162,7 @@ switch(sortBy) {
     results = hits.hits;
     break;
 }
+*/
 
 function hasBuckets(x: any): x is FacetData {
   return !!x && Array.isArray(x.buckets);
@@ -624,7 +629,7 @@ const facets = Object.entries(facetData).reduce((acc, [facetKey, data]) => {
     </div>
     <div>
       <form id="facets" method="GET" action={searchPageURL} class="vf-form">
-        {Object.entries(facets).map(([id, facet], i) => <>
+        {Object.entries(facets).map(([id, facet]) => <>
         <SearchFacet facet={facet} id={id} />
         </>
         )}

--- a/src/components/search/SearchCompactCards.astro
+++ b/src/components/search/SearchCompactCards.astro
@@ -1,9 +1,7 @@
 ---
-const { result, resultType, cardImageOverride } = Astro.props;
-import { getImage } from "astro:assets";
+const { result, resultType } = Astro.props;
 import imageFallback from "../../assets/bioimage-archive/image_fallback.png"
-import { getStudyImage, getThumbnail, formatPhysicalDimensions, formatPixelDimensions, getSimpleAttributeValue } from "../SharedJSFunctions.js";
-import {getImagingType, renderTaxonList, getAnnotationMethod} from "../cards/BrowseStudyCard.astro"
+import { getStudyImage, getThumbnail, formatPhysicalDimensions, formatPixelDimensions } from "../SharedJSFunctions.js";
 import {getImageRep} from "./SearchResultsTable.astro"
 
 const thumbnail = resultType === "study"? getStudyImage(result): getThumbnail(result);
@@ -11,8 +9,6 @@ const isFallback = resultType === "study"? String(thumbnail).includes("placehold
 const imageFallbackMessage = isFallback ? "Preview not available yet." : "";
 const studyfallbackMessage = isFallback ? "We cannot display images for this study yet." : "";
 const aspectRatio = resultType === "study"? "1/1.75": "1/1";
-const organism = resultType === "study"? renderTaxonList(result): "";
-const imagingMethod = resultType === "study"? getImagingType(result): "";
 
 
 const isNonZeroNumber = (v) => {

--- a/src/components/search/SearchResultsTable.astro
+++ b/src/components/search/SearchResultsTable.astro
@@ -1,7 +1,6 @@
 ---
 const { results, resultType, query, cardImageOverride } = Astro.props;
-import { getStudyImage, getThumbnail, formatPhysicalDimensions, formatPixelDimensions, getSimpleAttributeValue, highlightLinks, applyHighlight } from "../SharedJSFunctions.js";
-import {getImagingType, renderTaxonList, getAnnotationMethod, highlightImagingMethod, highlightOrganism} from "../cards/BrowseStudyCard.astro"
+import { highlightOrganism,  getStudyImage, getThumbnail, formatPhysicalDimensions, formatPixelDimensions, getSimpleAttributeValue, highlightLinks, applyHighlight, formatHighlightedList } from "../SharedJSFunctions.js";
 import  HighlightedText  from "../HighlightedText.astro";
 
 export function getImageRep(image){
@@ -12,33 +11,7 @@ export function getImageRep(image){
     return interactiveImageRepresentation
 }
 
-function highlightImagingMethodForImage(image, highlight, query){
-    const text =  [...new Set((image?.creation_process?.acquisition_process ?? []).flatMap(ap => ap?.imaging_method_name ?? []).filter(Boolean).sort())]
-    return text.flatMap(im=> highlightImagingMethod(im, highlight?.["creation_process.acquisition_process.imaging_method_name"], query)).join(", ")
-}
-
-function highlightOrganismForImage(image, highlight, query){
-    type Taxon = {
-        scientific_name?: string;
-        common_name?: string;
-    };
-    const taxons: Taxon[] = [
-    ...new Map(
-        (image?.creation_process?.subject?.sample_of ?? [])
-        .flatMap(s => s?.organism_classification ?? [])
-        .filter(Boolean)
-        .map((t: Taxon) => [
-            t.scientific_name || t.common_name,
-            { scientific_name: t.scientific_name, common_name: t.common_name }
-        ])
-    ).values()
-    ];
-    const taxonNames = taxons.map(t =>
-    t?.common_name ? `${t?.scientific_name} (${t?.common_name})` : t?.scientific_name
-    );
-    return taxonNames.map(taxon => query && taxon? applyHighlight(taxon, highlight?.['creation_process.subject.sample_of.organism_classification.common_name']?.[0] || highlight?.['creation_process.subject.sample_of.organism_classification.scientific_name']?.[0], query): taxon).join(", ")
-}
-function highlightImageFormat(image, highlight, query){
+function highlightImageFormat(image, query){
     const imageFormat = [
     ...new Set(
         (image?.representation ?? [])
@@ -46,7 +19,7 @@ function highlightImageFormat(image, highlight, query){
         .filter(Boolean).sort()
     )
     ];
-    const highLightedImageFormat = imageFormat.flatMap(imf=> query && imf? applyHighlight(imf, highlight?.["representation.image_format"]?.[0], query): imf)
+    const highLightedImageFormat = imageFormat.flatMap(imf=> query && imf? applyHighlight(imf, query): imf)
     return highLightedImageFormat
 }
 ---
@@ -64,7 +37,7 @@ function highlightImageFormat(image, highlight, query){
             ) : (
                 <th>Image</th>
                 <th>Organism</th>
-                <th>Imaging Method</th>
+                <th>Imaging Method/Annotation type</th>
                 <th>Image Formats</th>
                 <th>Physical Size</th>
                 <th>Pixels</th>
@@ -88,9 +61,9 @@ function highlightImageFormat(image, highlight, query){
                         <td><a class="vf-card__link" href={item?.highlight? highlightLinks(`/bioimage-archive/study/${item._source.accession_id}`, item.highlight, query): `/bioimage-archive/study/${item._source.accession_id}`} >{ item._source.accession_id }</a></td>
                         <td>{item._source.release_date}</td>
                         <td><HighlightedText text={item.highlight?.title?.[0] ?? item._source.title}/></td>
-                        <td><HighlightedText text={highlightImagingMethod(getImagingType(item._source), item.highlight?.["dataset.acquisition_process.imaging_method_name"], query)} /></td>
-                        <td><HighlightedText text={highlightOrganism(renderTaxonList(item._source), item.highlight, query)} /></td>
-                        <td><HighlightedText text={highlightImagingMethod(getAnnotationMethod(item._source).join(", "), item.highlight?.["dataset.annotation_process.method_type"], query)} /></td>
+                        <td><HighlightedText text={formatHighlightedList(item._source?.imaging_method, query, {sort: false})} /></td>
+                        <td><HighlightedText text={highlightOrganism(item._source, query)} /></td>
+                        <td><HighlightedText text={formatHighlightedList(item._source?.annotation_type?.map((at: string) => at.replace("_", " ")), query, {sort: false})} /></td>
                     </tr>
                 ): (
                     <tr>
@@ -99,9 +72,9 @@ function highlightImageFormat(image, highlight, query){
                                 <img src={getThumbnail(item._source)} alt="" style="width: 100px; height: 100px; object-fit: cover;" loading="lazy"/>
                             </a>
                         </td>
-                        <td><HighlightedText text={highlightOrganismForImage(item?._source, item?.highlight, query)} /></td>
-                        <td><HighlightedText text={highlightImagingMethodForImage(item?._source, item?.highlight, query)} />{}</td>
-                        <td><HighlightedText text={highlightImageFormat(item?._source, item?.highlight, query).join(", ")} /></td>
+                        <td><HighlightedText text={highlightOrganism(item._source, query)} /></td>
+                        <td><HighlightedText text={formatHighlightedList(item?._source?.imaging_method || item?._source?.annotation_type?.map((at: string) => at.replace(/_/g, " ")), query, {sort: false})} />{}</td>
+                        <td><HighlightedText text={highlightImageFormat(item?._source, query).join(", ")} /></td>
                         <td>{formatPhysicalDimensions(item._source)}</td>
                         <td>{getImageRep(item._source) && formatPixelDimensions(getImageRep(item._source))}</td>
                         <td>{getImageRep(item._source)?.size_c || ""}</td>

--- a/src/components/spatialomics/DatasetInfo.astro
+++ b/src/components/spatialomics/DatasetInfo.astro
@@ -26,19 +26,6 @@ function getTaxons(dataset) {
     return taxonHTMLList
 };
 
-function getBiologicalEntity(dataset) {
-    var biosamples
-    if (!dataset.biological_entity || !Array.isArray(dataset.biological_entity)) {
-        biosamples = [];
-    }
-
-    biosamples = dataset.biological_entity
-        .flatMap(entity => entity.biological_entity_description || []); 
-
-    return biosamples.reduce(formatListItem, "")
-};
-
-
 function getImagingType(dataset) {
     var imagingTypeList = new Array()
     for (var ia of dataset.acquisition_process) {
@@ -61,12 +48,6 @@ function displayImagingType(dataset) {
         return imgTypeDisplay
     }
 }
-
-function renderTaxonList(taxon_list) {
-    return taxon_list.reduce(formatListItem, "");
-}
-
-const taxons = getTaxons(dataset)
 
 ---
 

--- a/src/content/news_articles/0001_bia_default.md
+++ b/src/content/news_articles/0001_bia_default.md
@@ -6,4 +6,4 @@ figureLink: "galleries"
 ---
 EMBL-EBI’s BioImage Archive makes it easier to access and analyse biological research data.
 
-<a class="vf-summary__link" href="https://www.ebi.ac.uk/about/news/updates-from-data-resources/bioimage-archive-galleries/">Read More</a>
+<a target="_blank" class="vf-summary__link" href="https://www.ebi.ac.uk/about/news/updates-from-data-resources/bioimage-archive-galleries/">Read More</a>

--- a/src/content/news_articles/0002_ai_analysis.md
+++ b/src/content/news_articles/0002_ai_analysis.md
@@ -6,4 +6,4 @@ figureLink: "https://www.embl.org/news/science-technology/mifa-bioimaging/"
 ---
 Lack of incentives and low adoption of metadata standards are limiting AI’s potential for bioimage analysis – a community initiative proposes solutions.
 
-<a class="vf-summary__link" href="https://www.embl.org/news/science-technology/mifa-bioimaging/">Read More</a>
+<a target="_blank" class="vf-summary__link" href="https://www.embl.org/news/science-technology/mifa-bioimaging/">Read More</a>

--- a/src/content/news_articles/0003_ai4life_standards.md
+++ b/src/content/news_articles/0003_ai4life_standards.md
@@ -6,4 +6,4 @@ figureLink: "https://www.ebi.ac.uk/about/news/updates-from-data-resources/bioima
 ---
 In AI4Life, we believe that interoperability and standardisation are the backbone of a healthy AI research ecosystem, allowing data and models to be reused and combined across different research groups, institutions, and platforms. Without standards, valuable datasets and AI models often remain underutilised, difficult to reuse, reproduce, and less impactful than they could be.
 
-<a class="vf-summary__link" href="https://www.ebi.ac.uk/about/news/updates-from-data-resources/bioimage-archive-galleries/">Read More</a>
+<a target="_blank" class="vf-summary__link" href="https://www.ebi.ac.uk/about/news/updates-from-data-resources/bioimage-archive-galleries/">Read More</a>

--- a/src/content/news_articles/0004_elixir_cdf_ddb.md
+++ b/src/content/news_articles/0004_elixir_cdf_ddb.md
@@ -4,6 +4,6 @@ cover: ../../assets/bioimage-archive/news_elixir.png
 imageAlt: "Elixir CDR and DDB"
 figureLink: "https://elixir-europe.org/news/CDR-selection-2026"
 ---
-The BioImage Archive is now an ELIXIR <a href="https://elixir-europe.org/platforms/data/elixir-deposition-databases" class="vf-summary__link">Deposition Database</a> and <a href="https://elixir-europe.org/platforms/data/core-data-resources" class="vf-summary__link">Core Data Resource</a>.
+The BioImage Archive is now an ELIXIR <a target="_blank" href="https://elixir-europe.org/platforms/data/elixir-deposition-databases" class="vf-summary__link">Deposition Database</a> and <a target="_blank" href="https://elixir-europe.org/platforms/data/core-data-resources" class="vf-summary__link">Core Data Resource</a>.
 
-<a class="vf-summary__link" href="https://elixir-europe.org/news/CDR-selection-2026">Read More</a>
+<a target="_blank" class="vf-summary__link" href="https://elixir-europe.org/news/CDR-selection-2026">Read More</a>

--- a/src/pages/galleries/ai/ai-ready-studies.astro
+++ b/src/pages/galleries/ai/ai-ready-studies.astro
@@ -14,6 +14,7 @@ const studiesEntries = await Promise.all(
 );
 
 const studyMetadata = Object.fromEntries(studiesEntries) as Studies;
+
 ---
 <BaseLayout pageTitle={ collection.name }>
   <body>

--- a/src/pages/galleries/ai/ai-ready-study/[accessionID].astro
+++ b/src/pages/galleries/ai/ai-ready-study/[accessionID].astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayoutWithBreadcrumbs from "../../../../layouts/BaseLayoutWithBreadcrumbs.astro";
 import StudyTitleInfo from "../../../../components/study-page/StudyTitleInfo.astro";
-import { getThumbnail, getTaxons, getSimpleAttributeValue, getDatasetStatsByUUID, formatBytesToHumanSize, getAnnotationType, getStudyFromApiByAccession, generateSourceAnnotatedImageMap } from "../../../../components/SharedJSFunctions"
+import { getThumbnail, getTaxons, getSimpleAttributeValue, formatBytesToHumanSize, getAnnotationType, getStudyFromApiByAccession, generateSourceAnnotatedImageMap } from "../../../../components/SharedJSFunctions"
 import { type Study } from "../../../../components/SharedInterface.astro"
 import collection from '../../../../data/collections/ai-ready-datasets.json';
 import StudyContentsSummary from "../../../../components/study-page/StudyContentsSummary.astro"
@@ -16,7 +16,6 @@ export function getStaticPaths() {
 const { accessionID } = Astro.params;
 
 const study = await getStudyFromApiByAccession(accessionID) as Study;
-const datasetUUIDsAndFileStats = getDatasetStatsByUUID(study)
 const annotatedImagesMap = await generateSourceAnnotatedImageMap(study.accession_id);
 
 const allSourceImages = Array.from(annotatedImagesMap.values())
@@ -64,7 +63,7 @@ const modelContent = {
   "Model description": modelInformation?.description,
   "Model link": modelInformation?.link
 }
-const annotatedDatasetContent = annotationDatasets.map((dataset, index) => ({
+const annotatedDatasetContent = annotationDatasets.map((dataset) => ({
   dataset_title: dataset.title,
   organism: organism,
   imaging: imaging_method,

--- a/src/pages/galleries/ai/ai-ready-study/[accessionID].astro
+++ b/src/pages/galleries/ai/ai-ready-study/[accessionID].astro
@@ -64,7 +64,6 @@ const modelContent = {
   "Model description": modelInformation?.description,
   "Model link": modelInformation?.link
 }
-console.log(annotationDatasets)
 const annotatedDatasetContent = annotationDatasets.map((dataset, index) => ({
   dataset_title: dataset.title,
   organism: organism,

--- a/src/pages/galleries/ai/ai-ready-study/[accessionID].astro
+++ b/src/pages/galleries/ai/ai-ready-study/[accessionID].astro
@@ -17,19 +17,38 @@ const { accessionID } = Astro.params;
 
 const study = await getStudyFromApiByAccession(accessionID) as Study;
 const datasetUUIDsAndFileStats = getDatasetStatsByUUID(study)
-const annotatedImagesMap = await generateSourceAnnotatedImageMap(study);
-const organism = getTaxons(study).join(", ");
-// Need a better logic to identify source dataset and annotation dataset
-const sourceDataset = study.dataset.filter(ds => ds.acquisition_process.length > 0 && ds.annotation_process.length == 0);
-const allSourceImages = sourceDataset.flatMap(ds => ds.image || []);
-const imaging_method = Array.from(
-  new Set(sourceDataset.flatMap(ds => ds?.acquisition_process?.[0]?.imaging_method_name || []))
-).join(', ');
-const sourceExampleImageURI = sourceDataset.flatMap(ds => ds?.example_image_uri || []).filter(Boolean)[0];
-// Need a better logic to identify source dataset and annotation dataset
-const annotationDatasets = study.dataset.filter(ds => ds.acquisition_process.length == 0 && ds.annotation_process.length > 0);
-const annotationExampleImageURI = annotationDatasets.find(ad => ad.example_image_uri.length > 0)?.example_image_uri[0];
+const annotatedImagesMap = await generateSourceAnnotatedImageMap(study.accession_id);
 
+const allSourceImages = Array.from(annotatedImagesMap.values())
+  .filter(({ annotationImages }) => annotationImages.length > 0);
+
+  const organism = getTaxons(study).join(", ");
+
+const sourceDataset = study.dataset.filter(
+ds =>
+  (ds.acquisition_process?.length ?? 0) > 0 &&
+  (ds.annotation_process?.length ?? 0) === 0
+);
+
+const annotationDatasets = study.dataset.filter(
+  ds =>
+    (ds.acquisition_process?.length ?? 0) === 0 &&
+    (ds.annotation_process?.length ?? 0) > 0
+);
+
+const imaging_method = Array.from(
+  new Set(
+    sourceDataset.flatMap(ds =>
+      ds?.acquisition_process?.flatMap(ap => ap?.imaging_method_name || []) || []
+    )
+  )
+).join(", ");
+
+const sourceExampleImageURI =
+  sourceDataset.flatMap(ds => ds?.example_image_uri || []).filter(Boolean)[0] || "";
+
+const annotationExampleImageURI =
+  annotationDatasets.flatMap(ds => ds?.example_image_uri || []).filter(Boolean)[0] || "";
 const headlineStats = {
   "Total Viewable Images":  study.dataset.reduce((accumulator, dataset) => accumulator + dataset.image_count, 0),
   "Total files": study.dataset.reduce((accumulator, dataset) => accumulator + dataset.file_reference_count, 0),
@@ -119,54 +138,65 @@ const breadcrumbs = [
           </tr>
         </thead>
         <tbody class="vf_table__body">
-        {allSourceImages.filter(img=> annotatedImagesMap.has(img.uuid)).map((sourceImage, rowIndex) => {
-          const annotatedImgs = annotatedImagesMap.get(sourceImage.uuid) || [];
-          return (
-            <tr>
-              <td>
-                <a href={`/bioimage-archive/galleries/ai/image/${sourceImage?.uuid}` || "#"}>
-                <img src={getThumbnail(sourceImage)} alt="Preview" width="80" /></td>
+          {allSourceImages.map(({ sourceImage, annotationImages: annotatedImgs }, rowIndex) => (
+          <tr>
+            <td>
+                <a href={`/bioimage-archive/galleries/ai/image/${sourceImage.uuid}`}>
+                  <img src={getThumbnail(sourceImage)} alt="Preview" width="80" />
                 </a>
-              <td>
+            </td>
+            <td>
                 <div class="slideshow-container" data-row={rowIndex}>
-                {annotatedImgs.length > 1 ? annotatedImgs.map((annImg, i) => (
-                  <div class="slides fade" style={`display: ${i === 0 ? "block" : "none"}`}>
-                  <a href={`/bioimage-archive/galleries/ai/image/${sourceImage?.uuid}` || "#"}><img src={getThumbnail(annImg)} alt="Annotation Preview" width="80"/></a>
-                  </div>
-                )) : annotatedImgs.map((annImg) => (<a href={`/bioimage-archive/galleries/ai/image/${sourceImage?.uuid}` || "#"}><img src={getThumbnail(annImg)} alt="Annotation Preview" width="80"/></a>))
-                }
-                </div>
-              </td>
-              <td>{sourceImage.uuid}</td>
-              <td>{sourceDataset.find(dataset => dataset.image.some(image => image.uuid === sourceImage.uuid))?.title || ""}</td>
-              <td>
-                <div class="uuid-container">
                   {annotatedImgs.map((annImg, i) => (
-                    <span class="uuid" style={`display: ${i === 0 ? "inline" : "none"}`}>{annImg.uuid}</span>
+                    <div
+                      class="slides fade"
+                      style={`display: ${i === 0 ? "block" : "none"}`}
+                    >
+                      <a href={`/bioimage-archive/galleries/ai/image/${annImg.uuid}`}>
+                        <img
+                          src={getThumbnail(annImg)}
+                          alt="Annotation Preview"
+                          width="80"
+                        />
+                      </a>
+                    </div>
                   ))}
                 </div>
               </td>
-              <td>
-                <div class="dataset-title-container">
-                  {annotatedImgs.map((annImg, i) => {
-                    const dataset = study.dataset.find(ds =>
-                      ds.image?.some(image => image.uuid === annImg.uuid)
-                    );
-                    return (
-                      <span class="dataset-title" style={`display: ${i === 0 ? "inline" : "none"}`}>
-                        {dataset?.title || "P"}
-                      </span>
-                    );
-                  })}
-                </div>
-              </td>
-              <td>
-                <a href={`/bioimage-archive/galleries/ai/image/${sourceImage.uuid}`}>View</a>
-              </td>
-            </tr>
-          );
-        })}
-      </tbody>
+            <td>{sourceImage.uuid}</td>
+            <td>{sourceImage.dataset_title}</td>
+            <td>
+              <div class="uuid-container">
+                {annotatedImgs.map((annImg, i) => (
+                  <span
+                    class="uuid"
+                    style={`display: ${i === 0 ? "inline" : "none"}`}
+                  >
+                    {annImg.uuid}
+                  </span>
+                ))}
+              </div>
+            </td>
+            <td>
+              <div class="dataset-title-container">
+                {annotatedImgs.map((annImg, i) => (
+                  <span
+                    class="dataset-title"
+                    style={`display: ${i === 0 ? "inline" : "none"}`}
+                  >
+                    {annImg.dataset_title || ""}
+                  </span>
+                ))}
+              </div>
+            </td>
+            <td>
+              <a href={`/bioimage-archive/galleries/ai/image/${sourceImage.uuid}`}>
+                View
+              </a>
+            </td>
+          </tr>
+))}
+</tbody>
       </table>
     </div>
   </section>

--- a/src/pages/galleries/ai/ai-ready-study/[accessionID].astro
+++ b/src/pages/galleries/ai/ai-ready-study/[accessionID].astro
@@ -64,6 +64,7 @@ const modelContent = {
   "Model description": modelInformation?.description,
   "Model link": modelInformation?.link
 }
+console.log(annotationDatasets)
 const annotatedDatasetContent = annotationDatasets.map((dataset, index) => ({
   dataset_title: dataset.title,
   organism: organism,

--- a/src/pages/galleries/ai/analysed-studies.astro
+++ b/src/pages/galleries/ai/analysed-studies.astro
@@ -8,7 +8,7 @@ import {getStudyFromApiByAccession} from "../../../components/SharedJSFunctions.
 import additionalStudyInfo from '../../../data/ai-dataset-benchmarking/additional-study-metadata.json'
 
 const studiesEntries = await Promise.all(
-  Object.entries(additionalStudyInfo).map(async ([accessionID, studyAIInfo]) => {
+  Object.entries(additionalStudyInfo).map(async ([accessionID]) => {
     const study = await getStudyFromApiByAccession(accessionID);
     return [accessionID, study] as const;
   })

--- a/src/pages/galleries/ai/image/[uuid].astro
+++ b/src/pages/galleries/ai/image/[uuid].astro
@@ -2,7 +2,7 @@
 export const prerender = false;
 import BaseLayoutWithBreadcrumbs from '../../../../layouts/BaseLayoutWithBreadcrumbs.astro';
 import WebsiteStateButton from '../../../../components/WebsiteStateButton.astro';
-import { getTaxons, getAnnotationType, getImageFromAPI, getStudyFromApiByUUID, getAnnotationFromDerivedImages } from "../../../../components/SharedJSFunctions.js";
+import { getTaxons, getAnnotationType, getImageFromAPI, getStudyFromApiByAccession, getAnnotationFromDerivedImages } from "../../../../components/SharedJSFunctions.js";
 import SourceAnnotatedImage from '../../../../components/ai-gallery/SourceAnnotatedImage.astro';
 import { type Study } from "../../../../components/SharedInterface.astro"
 import StudyComponents from "../../../../components/ai-gallery/StudyComponents.astro";
@@ -10,8 +10,8 @@ import "../../../../styles/image_slider.css";
 
 const { uuid } = Astro.params;
 const image = await getImageFromAPI(uuid);
-const datasetUUID = image ? image.submission_dataset_uuid : "";
-const studyInfo = datasetUUID ? await getStudyFromApiByUUID(datasetUUID) as Study : {};
+const accession_id = image ? image.accession_id : "";
+const studyInfo: Study = await getStudyFromApiByAccession(accession_id);
 
 let sourceImage;
 let annotatedImages = [];
@@ -22,7 +22,7 @@ const vizarrURL = "https://livingobjects.ebi.ac.uk/bioimaging-01-pub/bia-zarr-te
 const sourceDataset = studyInfo.dataset.find((d) => d['uuid'] === sourceImage.submission_dataset_uuid);
 const imagingMethod = sourceDataset?.acquisition_process?.[0]?.imaging_method_name?.join(", ") || "";
 const annotationDatasets = studyInfo.dataset.filter(dataset => dataset.acquisition_process.length == 0 && dataset.annotation_process.length > 0);
-const annotatedDatasetContent = annotationDatasets.map((dataset, index) => ({
+const annotatedDatasetContent = annotationDatasets.map((dataset) => ({
   dataset_title: dataset.title,
   organism: organism,
   imaging: imagingMethod,

--- a/src/pages/galleries/spatialomics/image/[uuid].astro
+++ b/src/pages/galleries/spatialomics/image/[uuid].astro
@@ -7,8 +7,8 @@ import WebsiteStateButton from '../../../../components/WebsiteStateButton.astro'
 import fieldMap from "../../../../data/metadata-field-name-mapping.json";
 
 import fallbackImage from "../../../../assets/bioimage-archive/image_fallback.png"
-import {getSimpleAttributeValue, getImageFromAPI, getStudyFromApiByUUID } from "../../../../components/SharedJSFunctions.js"
-import { type Study } from "../../../../components/SharedInterface.astro"
+import {getSimpleAttributeValue, getImageFromAPI, getStudyFromApiByAccession } from "../../../../components/SharedJSFunctions.js"
+import { type Study, type ImageCreationProcess, type ImageRep } from "../../../../components/SharedInterface.astro"
 
 const biosampleMap = fieldMap["biosample"];
 const sippMap = fieldMap["specimen_imaging_preparation_protocol"];
@@ -19,13 +19,13 @@ const protocolMap = fieldMap["protocol"];
 const { uuid } = Astro.params;
 
 const image = await getImageFromAPI(uuid);
-const datasetUUID = image ? image.submission_dataset_uuid : "";
-const imageStudy = datasetUUID ? await getStudyFromApiByUUID(datasetUUID) as Study : {};
+const accession_id = image ? image.accession_id : "";
+const imageStudy: Study = await getStudyFromApiByAccession(accession_id);
 const vizarrRepUuid = getSimpleAttributeValue(image, "recommended_vizarr_representation");
 const interactiveImageRepresentation = image.representation.find(
     (rep) => rep.uuid === vizarrRepUuid
 )
-const imageDataset = imageStudy.dataset.find(ds => ds.uuid === image.submission_dataset_uuid);
+const imageDataset = imageStudy?.dataset.find(ds => ds.uuid === image.submission_dataset_uuid);
 
 const vizarrIFrameSource = interactiveImageRepresentation ? `https://livingobjects.ebi.ac.uk/bioimaging-01-pub/bia-zarr-test/vizarr/index.html?source=${interactiveImageRepresentation.file_uri[0]}` : null
 
@@ -36,7 +36,7 @@ const pref_ng_image_rep_uuid = getSimpleAttributeValue(image, "preferred_neurogl
 const pref_ng_image_rep = image.representation.find((rep) => rep.uuid === pref_ng_image_rep_uuid)
 const ng_link = pref_ng_image_rep ? getSimpleAttributeValue(pref_ng_image_rep, "neuroglancer_view_link")?.[0] : null
 
-const creation_process = image.creation_process
+const creation_process: ImageCreationProcess = image.creation_process || {}
 
 let specimen
 if ("subject" in creation_process && creation_process.subject != null) {
@@ -44,7 +44,7 @@ if ("subject" in creation_process && creation_process.subject != null) {
 }
 
 
-function formatPhysicalDimension(value, text) {
+function formatPhysicalDimension(value: string, text: string) {
     if (text === "") {
         if (value != null) {
             return value + "m"
@@ -60,14 +60,14 @@ function formatPhysicalDimension(value, text) {
     }
 }
 
-function formatPhysicalDimensions(imageRepresentation) {
+function formatPhysicalDimensions(imageRepresentation: ImageRep) {
     const fields = [ "voxel_physical_size_x", "voxel_physical_size_y", "voxel_physical_size_z"]
     const formattedStr =  fields.reduce((text, field) => formatPhysicalDimension(imageRepresentation[field], text), "")
     return formattedStr != "" ? formattedStr : 'Unknown'
 }
 
 
-function formatPixelDimension(value, text) {
+function formatPixelDimension(value: string, text: string) {
     if (text === "") {
         if (value != null) {
             return value
@@ -83,7 +83,7 @@ function formatPixelDimension(value, text) {
     }
 }
 
-function formatPixelDimensions(img_rep) {
+function formatPixelDimensions(img_rep: ImageRep) {
     const fields = [ "size_x", "size_y", "size_z"]
     return fields.reduce((text, field) => formatPixelDimension(img_rep[field], text), "")
 }
@@ -151,7 +151,7 @@ const breadcrumbs = [
   
               <div>
                   <h3>Access images</h3>
-                  License: <a href={imageStudy.licence}>{imageStudy.licence}</a> <br/>
+                  License: <a href={image.licence_details.uri}>{image.licence_details.label}</a> <br/>
                   <br/>
                   <a href={"/bioimage-archive/help/downloading-data#aws_client_download"}>How to download this image</a><br/>
                   <br/>
@@ -217,7 +217,7 @@ const breadcrumbs = [
               <div style="overflow-wrap: anywhere;">
                   <b>Title</b>: {imageStudy.title}<br/>
                   <b>Description:</b> {imageStudy.description} <br/>
-                  <b>Licence:</b> <a href={imageStudy.licence}>{imageStudy.licence}</a> <br/>
+                  <b>Licence:</b> <a href={imageStudy.licence_details.uri}>{imageStudy.licence_details.label}</a> <br/>
               </div>
           </section>
   

--- a/src/pages/galleries/spatialomics/image/[uuid].astro
+++ b/src/pages/galleries/spatialomics/image/[uuid].astro
@@ -8,7 +8,7 @@ import fieldMap from "../../../../data/metadata-field-name-mapping.json";
 
 import fallbackImage from "../../../../assets/bioimage-archive/image_fallback.png"
 import {getSimpleAttributeValue, getImageFromAPI, getStudyFromApiByAccession } from "../../../../components/SharedJSFunctions.js"
-import { type Study, type ImageCreationProcess, type ImageRep } from "../../../../components/SharedInterface.astro"
+import { type Study, type ImageCreationProcess, type ImageRep, type Image } from "../../../../components/SharedInterface.astro"
 
 const biosampleMap = fieldMap["biosample"];
 const sippMap = fieldMap["specimen_imaging_preparation_protocol"];
@@ -18,7 +18,7 @@ const protocolMap = fieldMap["protocol"];
 
 const { uuid } = Astro.params;
 
-const image = await getImageFromAPI(uuid);
+const image = await getImageFromAPI(uuid) as Image;
 const accession_id = image ? image.accession_id : "";
 const imageStudy: Study = await getStudyFromApiByAccession(accession_id);
 const vizarrRepUuid = getSimpleAttributeValue(image, "recommended_vizarr_representation");
@@ -96,7 +96,7 @@ const displayImageHTML = vizarrIFrameSource ? `<iframe style="width: 100%; heigh
 
 
 
-const userProvidedAttribute = image.additional_metadata?.find(attribute => attribute.name.includes("attributes_from_file_reference_"))?.value.attributes
+const userProvidedAttribute = image?.file_list_attributes?.[0]?.value.attributes || []
 
 const breadcrumbs = [
   "/bioimage-archive",

--- a/src/pages/galleries/spatialomics/study/[accessionID].astro
+++ b/src/pages/galleries/spatialomics/study/[accessionID].astro
@@ -8,7 +8,7 @@ import StudyFiles from '../../../../components/StudyFiles.astro';
 import SOTables from '../../../../components/spatialomics/SOTables.astro';
 import { type Study } from "../../../../components/SharedInterface.astro"
 import spatialomicsCollection from "../../../../data/collections/spatialomics.json"
-import { getStudyImage, getDatasetStatsByUUID, aggregateDatasetStats, getSimpleAttributeValue, getStudyFromApiByAccession, getImagesByAccessionID} from "../../../../components/SharedJSFunctions.js"
+import { getStudyImage, getDatasetStatsByUUID, getSimpleAttributeValue, getStudyFromApiByAccession, getImagesByAccessionID} from "../../../../components/SharedJSFunctions.js"
 import { PUBLIC_MONGO_API } from "astro:env/client";
 
 export function getStaticPaths() {
@@ -26,7 +26,7 @@ const datasetUUIDsAndFileStats = getDatasetStatsByUUID(study);
 
 let hasTranscripts = false;
 
-const fetchDatasetDetails = async (datasetUuid) => {
+const fetchDatasetDetails = async (datasetUuid: string) => {
     const pageSize = 1000; // Fetch up to 1000 file references to get the attributes
     const apiUrl = `${PUBLIC_MONGO_API}/dataset/${datasetUuid}/file_reference?page_size=${pageSize}`;
     const response = await fetch(apiUrl);
@@ -45,7 +45,7 @@ const fetchDatasetDetails = async (datasetUuid) => {
 };    
 
 const checkForTranscripts = async () => {
-    for (const [uuid, fileCount, title] of datasetUUIDsAndFileStats) {
+    for (const [uuid] of datasetUUIDsAndFileStats) {
         const dataType = await fetchDatasetDetails(uuid);
         if (dataType) {
             hasTranscripts = true;
@@ -123,7 +123,7 @@ const code_links = getSimpleAttributeValue(study, 'see_also_code')
 
       <div style="overflow-wrap: anywhere;">
         <!-- <div><b>Description: </b> <Fragment set:html={multilineTextRender(study.description)}></Fragment></div> -->
-        <div><b>Licence: </b> <a href={study.licence}>{study.licence}</a><div>
+        <div><b>Licence: </b> <a href={study.licence_details.uri}>{study.licence_details.label}</a><div>
         {
           omics_links && omics_links.length > 0 && (
             <div><b>Omics links: </b> <ul>{omics_links.map((link) => (<li class="vf-content">{link.description} <a href={link.link}>{link.link}</a></li>))}</ul></div>

--- a/src/pages/galleries/spatialomics/study/[accessionID].astro
+++ b/src/pages/galleries/spatialomics/study/[accessionID].astro
@@ -8,7 +8,7 @@ import StudyFiles from '../../../../components/StudyFiles.astro';
 import SOTables from '../../../../components/spatialomics/SOTables.astro';
 import { type Study } from "../../../../components/SharedInterface.astro"
 import spatialomicsCollection from "../../../../data/collections/spatialomics.json"
-import { getStudyImage, getDatasetStatsByUUID, aggregateDatasetStats, getSimpleAttributeValue, getStudyFromApiByAccession} from "../../../../components/SharedJSFunctions.js"
+import { getStudyImage, getDatasetStatsByUUID, aggregateDatasetStats, getSimpleAttributeValue, getStudyFromApiByAccession, getImagesByAccessionID} from "../../../../components/SharedJSFunctions.js"
 import { PUBLIC_MONGO_API } from "astro:env/client";
 
 export function getStaticPaths() {
@@ -67,7 +67,7 @@ if (hasTranscripts) {
 }
 
 
-const images = study.dataset.flatMap(dataset => dataset.image ?? [])
+const images = await getImagesByAccessionID(study.accession_id)
 
 const annotationDatasets = study.dataset.filter(dataset => 
   "annotation_process" in dataset && dataset.annotation_process && dataset.annotation_process.length > 0

--- a/src/pages/image/[uuid].astro
+++ b/src/pages/image/[uuid].astro
@@ -80,8 +80,7 @@ const displayImageHTML = vizarrIFrameSource ? `<iframe style="width: 100%; heigh
     thumbnail_uri ? `<img style="width: 100%; height: 500px" src="${thumbnail_uri}" />` :
     `<img style="height: 500px;" src="${fallbackImage.src}" />`
 
-const userProvidedAttribute = image.additional_metadata?.find(attribute => attribute.name.includes("attributes_from_file_reference_"))?.value.attributes || [];
-
+const userProvidedAttribute = image?.file_list_attributes?.[0]?.value.attributes || [];
 const breadcrumbs = [
   "/bioimage-archive",
   "/bioimage-archive/studies",
@@ -146,7 +145,7 @@ const breadcrumbs = [
                                     )}
                                 </div>
                             )}
-                            {userProvidedAttribute.length > 0 && ( 
+                            {userProvidedAttribute && ( 
                                 <div >
                                     <br/>
                                     <h4>Additional user metadata</h4>

--- a/src/pages/image/[uuid].astro
+++ b/src/pages/image/[uuid].astro
@@ -9,8 +9,8 @@ import ImageTable from '../../components/image/ImageTable.astro';
 
 import fieldMap from "../../data/metadata-field-name-mapping.json";
 import fallbackImage from "../../assets/bioimage-archive/image_fallback.png"
-import {getSimpleAttributeValue, getImageFromAPI, getImagesFromAPI, getStudyFromApiByUUID, formatPhysicalVoxelDimensions, formatPhysicalDimensions, formatPixelDimensions } from "../../components/SharedJSFunctions.js"
-import { type Study } from "../../components/SharedInterface.astro"
+import {getSimpleAttributeValue, getImageFromAPI, getImagesFromAPI, getStudyFromApiByAccession, formatPhysicalVoxelDimensions, formatPhysicalDimensions, formatPixelDimensions } from "../../components/SharedJSFunctions.js"
+import { type Study, type Image, type ImageCreationProcess, type SpecimenInfo } from "../../components/SharedInterface.astro"
 
 const imageAcquisitionMap = fieldMap["image_acquisition"];
 const annotationMethodMap = fieldMap["annotation_method"];
@@ -18,45 +18,46 @@ const protocolMap = fieldMap["protocol"];
 
 const { uuid } = Astro.params;
 
-const image = await getImageFromAPI(uuid);
+const image = await getImageFromAPI(uuid) as Image;
 
 const vizarrRepUuid = getSimpleAttributeValue(image, "recommended_vizarr_representation");
 const interactiveImageRepresentation = (image.representation.find(
     (rep) => rep.uuid == vizarrRepUuid
 ) ?? image.representation.find( (rep) => rep.image_format === ".ome.zarr") )
 
-const datasetUUID = image ? image.submission_dataset_uuid : "";
-const imageStudy = datasetUUID ? await getStudyFromApiByUUID(datasetUUID) as Study : {};
+const accession_id = image ? image.accession_id : "";
+const imageStudy: Study = await getStudyFromApiByAccession(accession_id);
 const imageDataset = imageStudy.dataset.find(ds => ds.uuid === image.submission_dataset_uuid);
 const vizarrIFrameSource = interactiveImageRepresentation ? `https://livingobjects.ebi.ac.uk/bioimaging-01-pub/bia-zarr-test/vizarr/index.html?source=${interactiveImageRepresentation.file_uri[0]}` : null
 const itkRepUuid = getSimpleAttributeValue(image, "recommended_itk_representation");
 const itkLink = itkRepUuid ? `https://kitware.github.io/itk-vtk-viewer/app/?fileToLoad=${interactiveImageRepresentation.file_uri[0]}` : null
-
+const file_path = image?.file_path;
 
 const pref_ng_image_rep_uuid = getSimpleAttributeValue(image, "preferred_neuroglancer_image_representation_uuid")
 const pref_ng_image_rep = image.representation.find((rep) => rep.uuid === pref_ng_image_rep_uuid)
 const ng_link = pref_ng_image_rep ? getSimpleAttributeValue(pref_ng_image_rep, "neuroglancer_view_link") : null
 
-const creation_process = image?.creation_process || [];
+const creation_process: ImageCreationProcess = image?.creation_process || {};
 
-var input_images = [];
+var input_images: Image[] = [];
 if ("input_image_uuid" in creation_process && creation_process.input_image_uuid.length > 0) {
     input_images = await getImagesFromAPI(creation_process.input_image_uuid)
 }
 
 
-let specimen
+let specimen: SpecimenInfo | null = null;
 if ("subject" in creation_process && creation_process.subject != null) {
     specimen = creation_process.subject
 }
-let inherited_specimens
+let inherited_specimens: SpecimenInfo[] = [];
 if (specimen == null && input_images.length > 0) {
     inherited_specimens = await recursivelyGetSpecimenInfo(input_images, new Map())
 }
 
-async function recursivelyGetSpecimenInfo(image_list, collected) {
+async function recursivelyGetSpecimenInfo(image_list: Image[],
+  collected: Map<string, SpecimenInfo>): Promise<SpecimenInfo[]> {
   for (const image of image_list) {
-    const specimen = image?.creation_process?.subject || null;
+    const specimen = image?.creation_process?.subject as SpecimenInfo | null;
 
     if (specimen != null) {
       collected.set(specimen.uuid, specimen);
@@ -79,8 +80,7 @@ const displayImageHTML = vizarrIFrameSource ? `<iframe style="width: 100%; heigh
     thumbnail_uri ? `<img style="width: 100%; height: 500px" src="${thumbnail_uri}" />` :
     `<img style="height: 500px;" src="${fallbackImage.src}" />`
 
-const userProvidedAttribute = image.additional_metadata?.find(attribute => attribute.name.includes("attributes_from_file_reference_"))?.value.attributes;
-
+const userProvidedAttribute = image.additional_metadata?.find(attribute => attribute.name.includes("attributes_from_file_reference_"))?.value.attributes || [];
 
 const breadcrumbs = [
   "/bioimage-archive",
@@ -118,7 +118,35 @@ const breadcrumbs = [
                             <b>Pixel image size: </b> {formatPixelDimensions(interactiveImageRepresentation)}<br />
                             {interactiveImageRepresentation.size_c && (<div><b>Number of channels:</b> {interactiveImageRepresentation.size_c}</div>)}
                             {interactiveImageRepresentation.size_t && (<div><b>Number of timesteps:</b> {interactiveImageRepresentation.size_t}</div>)}
-                            {userProvidedAttribute && ( 
+                            {file_path && (
+                                <div id="file-path-wrap">
+                                    <b>File Path:</b>
+                                    <span id="file-path-visible">
+                                    {file_path.slice(0, 2).join(", ")}
+                                    </span>
+
+                                    {file_path.length > 2 && (
+                                    <>
+                                        <span id="file-path-extra" hidden>
+                                        {", " + file_path.slice(2).join(", ")}
+                                        </span>
+
+                                        <br />
+
+                                        <button
+                                        id="file-path-toggle"
+                                        class="vf-button vf-button--primary vf-button--sm"
+                                        type="button"
+                                        aria-expanded="false"
+                                        style="margin-top:12px;"
+                                        >
+                                        See more
+                                        </button>
+                                    </>
+                                    )}
+                                </div>
+                            )}
+                            {userProvidedAttribute.length > 0 && ( 
                                 <div >
                                     <br/>
                                     <h4>Additional user metadata</h4>
@@ -141,7 +169,7 @@ const breadcrumbs = [
 
             <div>
                 <h3>Access images</h3>
-                License: <a href={imageStudy.licence}>{imageStudy.licence}</a> <br/>
+                License: <a href={image.licence_details.uri}>{image.licence_details.label}</a> <br/>
                 <br/>
                 <a href={"/bioimage-archive/help/downloading-data#aws_client_download"}>How to download this image</a><br/>
                 <br/>
@@ -184,7 +212,7 @@ const breadcrumbs = [
                         await copyUrl(copyUrlButton.dataset.url, copyUrlButton, originalText);
                     };
 
-                    async function copyUrl(url, button, originalText) {
+                    async function copyUrl(url: string, button: HTMLElement, originalText: string) {
                         await navigator.clipboard.writeText(url);
                         button.innerText = "URI Copied";
                         setTimeout(() => {
@@ -205,7 +233,7 @@ const breadcrumbs = [
             <div style="overflow-wrap: anywhere;">
                 <b>Title</b>: {imageStudy.title}<br/>
                 <b>Description:</b> {imageStudy.description} <br/>
-                <b>Licence:</b> <a href={imageStudy.licence}>{imageStudy.licence}</a> <br/>
+                <b>Licence:</b> <a href={imageStudy.licence_details.uri}>{imageStudy.licence_details.label}</a> <br/>
             </div>
         </section>
 
@@ -237,7 +265,7 @@ const breadcrumbs = [
                 specimen == null && inherited_specimens && inherited_specimens.length > 0 && (
                     <b>Source Specimen Information</b>
                     <ul> 
-                        {inherited_specimens.map((specimen) => (
+                        {inherited_specimens.map((specimen: SpecimenInfo) => (
                             <Specimen specimen={specimen}/>
                         ))}
                     </ul>
@@ -351,4 +379,60 @@ const breadcrumbs = [
 
   document.addEventListener("astro:page-load", initMetaCollapse);
   document.addEventListener("DOMContentLoaded", initMetaCollapse);
+</script>
+
+<script is:inline>
+  function initMetaCollapse() {
+    const wrap = document.getElementById("meta-wrap");
+    const content = document.getElementById("meta-content");
+    const btn = document.getElementById("meta-toggle");
+
+    const MAX = 250;
+
+    if (!wrap || !content || !btn) return;
+
+    const overflow = content.scrollHeight > MAX;
+
+    if (!overflow) {
+      btn.remove();
+      return;
+    }
+
+    wrap.dataset.collapsed = "true";
+    content.style.maxHeight = `${MAX}px`;
+    content.style.overflow = "hidden";
+
+    btn.onclick = () => {
+      const open = btn.getAttribute("aria-expanded") === "true";
+      btn.setAttribute("aria-expanded", String(!open));
+      btn.innerText = open ? "See more" : "See less";
+      wrap.dataset.collapsed = String(open);
+      content.style.maxHeight = open ? `${MAX}px` : "";
+    };
+  }
+
+  function initFilePathCollapse() {
+    const extra = document.getElementById("file-path-extra");
+    const btn = document.getElementById("file-path-toggle");
+
+    if (!extra || !btn) return;
+
+    btn.onclick = () => {
+      const open = btn.getAttribute("aria-expanded") === "true";
+
+      btn.setAttribute("aria-expanded", String(!open));
+      btn.innerText = open ? "See more" : "See less";
+      extra.hidden = open;
+    };
+  }
+
+  document.addEventListener("astro:page-load", () => {
+    initMetaCollapse();
+    initFilePathCollapse();
+  });
+
+  document.addEventListener("DOMContentLoaded", () => {
+    initMetaCollapse();
+    initFilePathCollapse();
+  });
 </script>

--- a/src/pages/images.astro
+++ b/src/pages/images.astro
@@ -29,7 +29,7 @@ let pageTitle = query.length === 0? "Browse Images": "Search Images";
   var toggle = document.getElementById('image_toggle');
 
   toggle.addEventListener('change', (event) => {
-    const sortBy = event.target.value;
+    //const sortBy = event.target.value;
     const url = new URL(window.location.href);
     url.searchParams.set('hasImages', toggle.checked);
     window.location.href = url.toString();

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,13 +7,10 @@ import galleriesImage from "../assets/bioimage-archive/galleries_embl_green.png"
 import helpImage from "../assets/bioimage-archive/help_embl_green.png";
 import policiesImage from "../assets/bioimage-archive/policies_embl_green.png";
 import aboutImage from "../assets/bioimage-archive/aboutus_embl_green.png";
-
-import getInTouchImage from "../assets/bioimage-archive/get_in_touch.png";
 import biaLogo from "../assets/bioimage-archive/BIA_new_logo.png"
 import emailImage from "../assets/bioimage-archive/email_embl_green.png";
 import githubImage from "../assets/bioimage-archive/github_embl_green.png";
 import blueskyImage from "../assets/bioimage-archive/bluesky_embl_green.png";
-import youtubeImage from "../assets/bioimage-archive/youtube.png";
 import NewsSection from "../components/News.astro"
 import ukriImage from "../assets/bioimage-archive/uk_ri_logo.jpg";
 import emblImage from "../assets/bioimage-archive/EMBL_logo_colour_wordmark.png";
@@ -174,7 +171,7 @@ import bannerImage from "../assets/bioimage-archive/banner.webp";
           >
         </div>
         <div class="column column-block">
-          <a href="https://github.com/BioImage-Archive" class="vf-link logo-img">
+          <a target="_blank" href="https://github.com/BioImage-Archive" class="vf-link logo-img">
             <img
               class="vf-figure__image"
               src={githubImage.src}
@@ -183,7 +180,7 @@ import bannerImage from "../assets/bioimage-archive/banner.webp";
           >
         </div>
         <div class="column column-block">
-          <a href="https://bsky.app/profile/bioimagearchive.bsky.social" class="vf-link logo-img">
+          <a target="_blank" href="https://bsky.app/profile/bioimagearchive.bsky.social" class="vf-link logo-img">
             <img
               class="vf-figure__image"
               src={blueskyImage.src}
@@ -214,7 +211,7 @@ import bannerImage from "../assets/bioimage-archive/banner.webp";
   <section class="vf-content;" style="padding: 1% 1%;margin-left: 10%; margin-right: 10%;">
     <div style="display: flex; justify-content: space-between; flex-wrap: wrap;">
       <span class="column column-block">
-        <a href="https://www.ukri.org/" class="logo-img">
+        <a target="_blank" href="https://www.ukri.org/" class="logo-img">
           <img
             class="padding-bottom-large"
             src={ukriImage.src}
@@ -224,7 +221,7 @@ import bannerImage from "../assets/bioimage-archive/banner.webp";
         </a>
       </span>
       <span class="column column-block">
-        <a href="https://www.embl.org" class="logo-img">
+        <a target="_blank" href="https://www.embl.org" class="logo-img">
           <img
             class="padding-bottom-large"
             src={emblImage.src}
@@ -234,7 +231,7 @@ import bannerImage from "../assets/bioimage-archive/banner.webp";
         </a>
       </span>
       <span class="column column-block">
-        <a href="https://commission.europa.eu/funding-tenders/find-funding/eu-funding-programmes_en" class="logo-img">
+        <a target="_blank" href="https://commission.europa.eu/funding-tenders/find-funding/eu-funding-programmes_en" class="logo-img">
           <img
             class="padding-bottom-large"
             src={euImage.src}

--- a/src/pages/studies.astro
+++ b/src/pages/studies.astro
@@ -32,7 +32,7 @@ let pageTitle = query.length === 0? "Browse Studies": "Search Studies";
   var toggle = document.getElementById('image_toggle');
 
   toggle.addEventListener('change', (event) => {
-    const sortBy = event.target.value;
+    //const sortBy = event.target.value;
     const url = new URL(window.location.href);
     url.searchParams.set('hasImages', toggle.checked);
     window.location.href = url.toString();

--- a/src/pages/study/[accessionID].astro
+++ b/src/pages/study/[accessionID].astro
@@ -4,7 +4,6 @@ import StudyTitleInfo from "../../components/study-page/StudyTitleInfo.astro";
 import StudyContentsSummary from "../../components/study-page/StudyContentsSummary.astro";
 import DatasetInfo from "../../components/DatasetInfo.astro";
 import ViewableImageTable from "../../components/ViewableImageTable.astro";
-import DatasetFilesTable from "../../components/DatasetFilesTable.astro";
 import StudyFiles from "../../components/StudyFiles.astro";
 import Citation from "../../components/Citation.astro";
 
@@ -29,7 +28,7 @@ const tableOfContents = {
 
 const { accessionID } = Astro.params;
 const study = await getStudyFromApiByAccession(accessionID) as Study;
-const images = study?.dataset.flatMap(dataset => dataset.image ?? [])
+const images = study?.image ?? []
 
 if (!Array.isArray(study.see_also) || study.see_also.length === 0) {
   delete tableOfContents["Linked Information"];
@@ -72,7 +71,6 @@ function getFileTypes(study) {
     return fileTypeList
 }
 
-const datasetUUIDsAndFileStats = getDatasetStatsByUUID(study);
 const exampleStudyImage = getStudyImage(study);
 
 function getImageUUIDFromStudyImage(exampleURI, images){

--- a/src/pages/study/[accessionID].astro
+++ b/src/pages/study/[accessionID].astro
@@ -7,7 +7,7 @@ import ViewableImageTable from "../../components/ViewableImageTable.astro";
 import StudyFiles from "../../components/StudyFiles.astro";
 import Citation from "../../components/Citation.astro";
 
-import { getMetadataValue, multilineTextRender, formatBytesToHumanSize, getStudyImage, getDatasetStatsByUUID, getStudyFromApiByAccession, getAllStudiesFromAPI} from "../../components/SharedJSFunctions.js"
+import { getMetadataValue, multilineTextRender, formatBytesToHumanSize, getStudyImage, getStudyFromApiByAccession, getAllStudiesFromAPI} from "../../components/SharedJSFunctions.js"
 import { type Study } from "../../components/SharedInterface.astro"
 
 export async function getStaticPaths() {
@@ -59,21 +59,10 @@ if (study?.grant && Array.isArray(study.grant)) {
   }
 }
 // End grant pre-processing
-function getFileTypes(study) {
-    const fileTypeList = []
-    for (var dataset of study.dataset) {
-        for (const file_type of dataset.file_type_aggregation) {
-            if (!fileTypeList.includes(file_type)) {
-              fileTypeList.push(file_type)
-            }
-        }
-    }
-    return fileTypeList
-}
 
 const exampleStudyImage = getStudyImage(study);
 
-function getImageUUIDFromStudyImage(exampleURI, images){
+function getImageUUIDFromStudyImage(exampleURI: string, images: any[]){
   const thumbnailImage = images.find(img => {
     const meta = getMetadataValue(img.additional_metadata, "image_static_display_uri");
     return meta?.slice?.uri === exampleURI;
@@ -95,7 +84,7 @@ const linkTypeFormatting = {
   "arrayexpress": "ArrayExpress",
   "empiar": "EMPIAR"
 }
-function formatLinkType(link_type) {
+function formatLinkType(link_type: string) {
   if (!link_type) return "";
   return linkTypeFormatting[link_type.toLowerCase()] ?? link_type;
 }
@@ -169,13 +158,13 @@ const breadcrumbs = [
       </div>      
     )}
     <div class="study-info-item">
-      <b>Licence: </b> <a href={study.licence}>{study.licence}</a>
+      <b>Licence: </b> <a href={study.licence_details.uri}>{study.licence_details.label}</a>
     </div>
     {Array.isArray(study.related_publication) && study.related_publication.length > 0 && (
       <div class="study-info-item">
         <b>Publication:</b>
         <ul>
-          {study.related_publication.map((pub, i) => {
+          {study.related_publication.map((pub) => {
             const { authors_name, publication_year, title, pubmed_id, doi } = pub;
             const titleLink = pubmed_id ? `https://pubmed.ncbi.nlm.nih.gov/${pubmed_id}` : null;
             const doiLink = doi ? doi : null;
@@ -261,7 +250,7 @@ const breadcrumbs = [
       <div>
         <ul>
           {
-            study.see_also.map((linkedInfo, i) => {
+            study.see_also.map((linkedInfo) => {
               const { link, link_type, description } = linkedInfo;
               return (
                 <li style={{ fontSize: "inherit", lineHeight: "inherit" }}>


### PR DESCRIPTION
https://app.clickup.com/t/869d724na

Key changes:
- Dynamic viewable images table on study pages
- On images you can now search for:
   - Author names, affiliation, orcid, rorid
   - FIle list values
   - dataset title
   - file path/label
-  Browse/search uses cards view (smaller json)
- Study and image pages uses whole study/image object