### PR TITLE
Specimen track display

### DIFF
--- a/src/components/SharedInterface.astro
+++ b/src/components/SharedInterface.astro
@@ -42,11 +42,17 @@ export interface Image {
   uuid: string;
   additional_metadata?: any[];
   file_path?: string[];
+  file_uri?: string[];
+  total_size_in_bytes?: number;
   submission_dataset_uuid: string;
   creation_process?: ImageCreationProcess;
   licence_details: Licence;
   accession_id: string;
   file_list_attributes: any[];
+  image_role?: "intermediate" | "terminal_display" | "terminal_segmentation";
+  is_initial_image?: boolean;
+  upstream_image_uuids?: string[];
+  terminal_display_image_uuids?: string[];
 }
 
 export interface SpecimenInfo {

--- a/src/components/SharedJSFunctions.js
+++ b/src/components/SharedJSFunctions.js
@@ -303,6 +303,12 @@ export async function getImagesFromAPI(uuid_list){
   return image_list;
 }
 
+export async function getDownstreamDisplayImages(uuid){
+    const response = await getFromAPI(`${PUBLIC_SEARCH_API}/website/image?facet.downstream_of=${uuid}&facet.image_role=terminal_display`);
+    const displayImages = response?.hits?.hits?.map(img => img._source) ?? [];
+    return displayImages
+}
+
 
 async function getAllPaginatedHits(urlBuilder, pageSize = 100) {
   const firstPage = await getFromAPI(urlBuilder(1, pageSize));

--- a/src/components/image/DisplayImageTable.astro
+++ b/src/components/image/DisplayImageTable.astro
@@ -1,0 +1,35 @@
+---
+import SpecimenTrackTableRow from "./SpecimenTrackTableRow.astro";
+
+const { images } = Astro.props;
+---
+<div class="specimen-track-table">
+  <table class="vf-table">
+    <thead>
+      <tr>
+        <th>Role</th>
+        <th>Label</th>
+        <th>UUID</th>
+        <th>File size</th>
+        <th>Download</th>
+      </tr>
+    </thead>
+    <tbody>
+      {images.map((image) => <SpecimenTrackTableRow image={image} />)}
+    </tbody>
+  </table>
+</div>
+
+<style>
+  .specimen-track-table table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  .specimen-track-table th,
+  .specimen-track-table td {
+    text-align: left;
+    padding: 8px 12px;
+    border-bottom: 1px solid #d2d2d2;
+    font-size: 14px;
+  }
+</style>

--- a/src/components/image/SpecimenTrackTable.astro
+++ b/src/components/image/SpecimenTrackTable.astro
@@ -1,25 +1,14 @@
 ---
-import { formatBytesToHumanSize } from "../SharedJSFunctions";
+import SpecimenTrackTableRow from "./SpecimenTrackTableRow.astro";
 
 const { images } = Astro.props;
 
 const sortedImages = [...images].sort((a, b) =>
   a.is_initial_image === b.is_initial_image ? 0 : a.is_initial_image ? 1 : -1
 );
-
-const roleLabels: Record<string, string> = {
-  intermediate: "Intermediate",
-  terminal_display: "Terminal display",
-  terminal_segmentation: "Terminal segmentation",
-};
-
-function combinedRoleLabel(image): string {
-  const base = roleLabels[image.image_role] ?? image.image_role;
-  return image.is_initial_image ? `Initial · ${base}` : base;
-}
 ---
 <div class="specimen-track-table">
-  <table class="vf-table">
+  <table id="specimen_track_table" class="vf-table">
     <thead>
       <tr>
         <th>Role</th>
@@ -28,35 +17,13 @@ function combinedRoleLabel(image): string {
         <th>File size</th>
         <th>Download</th>
       </tr>
+      <tr>
+        <th id="role_filter_cell"></th>
+        <th></th><th></th><th></th><th></th>
+      </tr>
     </thead>
     <tbody>
-      {
-        sortedImages.map((image) => (
-          <tr>
-            <td>
-              <span class={image.image_role}>
-                {combinedRoleLabel(image)}
-              </span>
-            </td>
-            <td>
-              {image.label ?? image.uuid}
-            </td>
-            <td>
-                <a href={`/bioimage-archive/image/${image.uuid}`}>{image.uuid}</a>
-            </td>
-            <td>
-                {image.total_size_in_bytes != null 
-                    ? formatBytesToHumanSize(image.total_size_in_bytes) 
-                    : "N/A"}  
-            </td>
-            <td>
-                {image.file_uri?.[0] && (
-                    <a href={image.file_uri[0]} download>Download</a>
-                )}
-            </td>
-          </tr>
-        ))
-      }
+      {sortedImages.map((image) => <SpecimenTrackTableRow image={image} />)}
     </tbody>
   </table>
 </div>
@@ -74,3 +41,37 @@ function combinedRoleLabel(image): string {
     font-size: 14px;
   }
 </style>
+
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    $("#specimen_track_table").DataTable({
+      order: [],
+      orderCellsTop: false,
+      columnDefs: [
+        { type: "natural", targets: 0 },
+        { orderable: false, targets: [1, 2, 4] },
+      ],
+      initComplete: function () {
+        this.api()
+          .columns(0)
+          .every(function (this: any) {
+            const column = this;
+            const select = $('<select><option value="">All roles</option></select>')
+              .appendTo($("#role_filter_cell"))
+              .on("change", function (this: HTMLSelectElement) {
+                const value = $.fn.dataTable.util.escapeRegex(String($(this).val() ?? ""));
+                column.search(value ? `^${value}$` : "", true, false).draw();
+              });
+
+            column
+              .data()
+              .unique()
+              .sort()
+              .each(function (roleText: string) {
+                select.append(`<option value="${roleText}">${roleText}</option>`);
+              });
+          });
+      },
+    });
+  });
+</script>

--- a/src/components/image/SpecimenTrackTable.astro
+++ b/src/components/image/SpecimenTrackTable.astro
@@ -1,0 +1,76 @@
+---
+import { formatBytesToHumanSize } from "../SharedJSFunctions";
+
+const { images } = Astro.props;
+
+const sortedImages = [...images].sort((a, b) =>
+  a.is_initial_image === b.is_initial_image ? 0 : a.is_initial_image ? 1 : -1
+);
+
+const roleLabels: Record<string, string> = {
+  intermediate: "Intermediate",
+  terminal_display: "Terminal display",
+  terminal_segmentation: "Terminal segmentation",
+};
+
+function combinedRoleLabel(image): string {
+  const base = roleLabels[image.image_role] ?? image.image_role;
+  return image.is_initial_image ? `Initial · ${base}` : base;
+}
+---
+<div class="specimen-track-table">
+  <table class="vf-table">
+    <thead>
+      <tr>
+        <th>Role</th>
+        <th>Label</th>
+        <th>UUID</th>
+        <th>File size</th>
+        <th>Download</th>
+      </tr>
+    </thead>
+    <tbody>
+      {
+        sortedImages.map((image) => (
+          <tr>
+            <td>
+              <span class={image.image_role}>
+                {combinedRoleLabel(image)}
+              </span>
+            </td>
+            <td>
+              {image.label ?? image.uuid}
+            </td>
+            <td>
+                <a href={`/bioimage-archive/image/${image.uuid}`}>{image.uuid}</a>
+            </td>
+            <td>
+                {image.total_size_in_bytes != null 
+                    ? formatBytesToHumanSize(image.total_size_in_bytes) 
+                    : "N/A"}  
+            </td>
+            <td>
+                {image.file_uri?.[0] && (
+                    <a href={image.file_uri[0]} download>Download</a>
+                )}
+            </td>
+          </tr>
+        ))
+      }
+    </tbody>
+  </table>
+</div>
+
+<style>
+  .specimen-track-table table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  .specimen-track-table th,
+  .specimen-track-table td {
+    text-align: left;
+    padding: 8px 12px;
+    border-bottom: 1px solid #d2d2d2;
+    font-size: 14px;
+  }
+</style>

--- a/src/components/image/SpecimenTrackTableRow.astro
+++ b/src/components/image/SpecimenTrackTableRow.astro
@@ -1,0 +1,31 @@
+---
+import { formatBytesToHumanSize } from "../SharedJSFunctions";
+
+const { image } = Astro.props;
+
+const roleLabels: Record<string, string> = {
+  intermediate: "Intermediate",
+  terminal_display: "Terminal display",
+  terminal_segmentation: "Terminal segmentation",
+};
+
+function combinedRoleLabel(image): string {
+  const base = roleLabels[image.image_role] ?? image.image_role;
+  return image.is_initial_image ? `Initial · ${base}` : base;
+}
+---
+<tr>
+  <td>{combinedRoleLabel(image)}</td>
+  <td>{image.label ?? image.uuid}</td>
+  <td><a href={`/bioimage-archive/image/${image.uuid}`}>{image.uuid}</a></td>
+  <td>
+    {image.total_size_in_bytes != null
+      ? formatBytesToHumanSize(image.total_size_in_bytes)
+      : "N/A"}
+  </td>
+  <td>
+    {image.file_uri?.[0] && (
+      <a href={image.file_uri[0]} download>Download</a>
+    )}
+  </td>
+</tr>

--- a/src/pages/image/[uuid].astro
+++ b/src/pages/image/[uuid].astro
@@ -5,6 +5,7 @@ import BaseLayoutWithBreadcrumbs from '../../layouts/BaseLayoutWithBreadcrumbs.a
 import DatasetDetail from '../../components/DatasetDetail.astro';
 import WebsiteStateButton from '../../components/WebsiteStateButton.astro';
 import Specimen from '../../components/image/Specimen.astro';
+import SpecimenTrackTable from '../../components/image/SpecimenTrackTable.astro';
 import ImageTable from '../../components/image/ImageTable.astro';
 
 import fieldMap from "../../data/metadata-field-name-mapping.json";
@@ -44,36 +45,22 @@ if ("input_image_uuid" in creation_process && creation_process.input_image_uuid.
     input_images = await getImagesFromAPI(creation_process.input_image_uuid)
 }
 
+let upstream_images: Image[] = [];
+if (image.upstream_image_uuids?.length > 0) {
+    upstream_images = await getImagesFromAPI(image.upstream_image_uuids);
+}
 
 let specimen: SpecimenInfo | null = null;
 if ("subject" in creation_process && creation_process.subject != null) {
     specimen = creation_process.subject
 }
 let inherited_specimens: SpecimenInfo[] = [];
-if (specimen == null && input_images.length > 0) {
-    inherited_specimens = await recursivelyGetSpecimenInfo(input_images, new Map())
-}
-
-async function recursivelyGetSpecimenInfo(image_list: Image[],
-  collected: Map<string, SpecimenInfo>): Promise<SpecimenInfo[]> {
-  for (const image of image_list) {
-    const specimen = image?.creation_process?.subject as SpecimenInfo | null;
-
-    if (specimen != null) {
-      collected.set(specimen.uuid, specimen);
-      continue;
+if (specimen == null) {
+    const initialImage = upstream_images.find(img => img?.is_initial_image);
+    if (initialImage?.creation_process?.subject) {
+        inherited_specimens = [initialImage.creation_process.subject];
     }
-    const next_image_uuids = image?.creation_process?.input_image_uuid || [];
-
-    if (collected.size == 0 && next_image_uuids.length > 0) {
-      const next_images = await getImagesFromAPI(next_image_uuids);
-      await recursivelyGetSpecimenInfo(next_images, collected);
-    }
-  }
-  const specimens = Array.from(collected.values());
-  return specimens
 }
-
 
 const thumbnail_uri = getSimpleAttributeValue(image, "thumbnail_uri")?.[0];
 const displayImageHTML = vizarrIFrameSource ? `<iframe style="width: 100%; height: 500px" name="vizarr" src="${vizarrIFrameSource}"></iframe>` :
@@ -334,6 +321,24 @@ const breadcrumbs = [
                             <b>Input Images:</b>
                         </div>
                         <ImageTable images={input_images}/>
+                    )
+                }
+            </div>
+        </section>
+
+        <hr/>
+
+        <section class="vf-intro | embl-grid embl-grid--has-centered-content | section-spacing">
+            <div class="vf-section-header">
+                <h2 class="vf-section-header__heading" >Specimen track</h2>
+            </div>
+            <div>
+                {
+                    image.image_role === "terminal_display" && upstream_images.length > 0 && (
+                        <div>
+                            <b>Upstream Images:</b>
+                        </div>
+                        <SpecimenTrackTable images={upstream_images}/>
                     )
                 }
             </div>

--- a/src/pages/image/[uuid].astro
+++ b/src/pages/image/[uuid].astro
@@ -6,11 +6,12 @@ import DatasetDetail from '../../components/DatasetDetail.astro';
 import WebsiteStateButton from '../../components/WebsiteStateButton.astro';
 import Specimen from '../../components/image/Specimen.astro';
 import SpecimenTrackTable from '../../components/image/SpecimenTrackTable.astro';
+import DisplayImageTable from '../../components/image/DisplayImageTable.astro';
 import ImageTable from '../../components/image/ImageTable.astro';
 
 import fieldMap from "../../data/metadata-field-name-mapping.json";
 import fallbackImage from "../../assets/bioimage-archive/image_fallback.png"
-import {getSimpleAttributeValue, getImageFromAPI, getImagesFromAPI, getStudyFromApiByAccession, formatPhysicalVoxelDimensions, formatPhysicalDimensions, formatPixelDimensions } from "../../components/SharedJSFunctions.js"
+import {getSimpleAttributeValue, getImageFromAPI, getImagesFromAPI, getDownstreamDisplayImages, getStudyFromApiByAccession, formatPhysicalVoxelDimensions, formatPhysicalDimensions, formatPixelDimensions } from "../../components/SharedJSFunctions.js"
 import { type Study, type Image, type ImageCreationProcess, type SpecimenInfo } from "../../components/SharedInterface.astro"
 
 const imageAcquisitionMap = fieldMap["image_acquisition"];
@@ -49,6 +50,21 @@ let upstream_images: Image[] = [];
 if (image.upstream_image_uuids?.length > 0) {
     upstream_images = await getImagesFromAPI(image.upstream_image_uuids);
 }
+
+let display_images: Image[] = [];
+if (image.image_role === "terminal_segmentation" && image.terminal_display_image_uuids?.length > 0) {
+    display_images = await getImagesFromAPI(image.terminal_display_image_uuids);
+}
+
+let downstream_display_images: Image[] = [];
+if (image.image_role === "intermediate") {
+    downstream_display_images = await getDownstreamDisplayImages(image.uuid);
+}
+
+const hasSpecimenTrackContent =
+    (image.image_role === "terminal_display" && upstream_images.length > 0) ||
+    (image.image_role === "terminal_segmentation" && display_images.length > 0) ||
+    (image.image_role === "intermediate" && downstream_display_images.length > 0);
 
 let specimen: SpecimenInfo | null = null;
 if ("subject" in creation_process && creation_process.subject != null) {
@@ -326,23 +342,40 @@ const breadcrumbs = [
             </div>
         </section>
 
-        <hr/>
-
-        <section class="vf-intro | embl-grid embl-grid--has-centered-content | section-spacing">
-            <div class="vf-section-header">
-                <h2 class="vf-section-header__heading" >Specimen track</h2>
-            </div>
-            <div>
-                {
-                    image.image_role === "terminal_display" && upstream_images.length > 0 && (
-                        <div>
-                            <b>Upstream Images:</b>
+        {
+            hasSpecimenTrackContent && (
+                <>
+                    <hr/>
+                    <section class="vf-intro | embl-grid embl-grid--has-centered-content | section-spacing">
+                        <div class="vf-section-header">
+                            <h2 class="vf-section-header__heading" >Specimen track</h2>
                         </div>
-                        <SpecimenTrackTable images={upstream_images}/>
-                    )
-                }
-            </div>
-        </section>
+                        <div>
+                            {
+                                image.image_role === "terminal_display" && upstream_images.length > 0 && (
+                                    <div>
+                                        <b>Upstream Images:</b>
+                                    </div>
+                                    <SpecimenTrackTable images={upstream_images}/>
+                                )
+                            }
+                            {
+                                image.image_role === "terminal_segmentation" && display_images.length > 0 && (
+                                    <div><b>Terminal Images:</b></div>
+                                    <DisplayImageTable images={display_images}/>
+                                )
+                            }
+                            {
+                                image.image_role === "intermediate" && downstream_display_images.length > 0 && (
+                                    <div><b>Terminal Images:</b></div>
+                                    <DisplayImageTable images={downstream_display_images}/>
+                                )
+                            }
+                        </div>
+                    </section>
+                </>
+            )
+        }
     </body>
 </BaseLayout>
 <style>


### PR DESCRIPTION
For this ticket: https://app.clickup.com/t/9012007505/869e5k8c1

And using the updates from the specimen-track work in bia-export/bia-search (https://gitlab.ebi.ac.uk/bioimage-archive/bia-integrator/-/merge_requests/612). That PR adds classification of an image's position in its processing chain (the specimen track) and query it; this one is to use that on the website.

*Some specific considerations:*
1. Currently, as described below, the new "Specimen track" section is independent of the "Creation" section, meaning that "Input Images" (in the latter) and "Upstream Images" (in the former) somewhat duplicate one another (see screenshot below) — perhaps these could be combined?

<img width="554" height="727" alt="Screenshot 2026-07-23 at 15 00 38" src="https://github.com/user-attachments/assets/e2a7ac39-b152-44f0-9d5d-0690422bef3c" />

2. One edge case: `upstream_image_uuids` has no role filtering, so if some image in a track was ever built using a segmentation as one of its own inputs, that segmentation would appear as a row in the "Upstream Images" table. It isn't especially handled — the role-label lookup table simply keeps terminal_segmentation as a mapped value rather than only the two roles expected to typically appear there, so if it ever does show up, it renders as a normal, correctly labeled row rather than an unformatted fallback string.

*And a more detailed summary of changes, with a rationale:*

`SharedInterface.astro` — `Image` gets `image_role`, `is_initial_image`, `upstream_image_uuids`, `terminal_display_image_uuids`, and `file_uri`, matching the five new export fields.

`image/[uuid].astro` — I replaced the specimen lookup (`recursivelyGetSpecimenInfo`, a recursive function making one API call per hop up the ancestor chain) with a single fetch. On top of that, a new "Specimen track" section renders one of three things depending on the viewed image's role, and disappears entirely (heading included) when there's nothing to show rather than rendering empty:

`terminal_display` → an "Upstream Images" table, the image's full ancestor chain.

`terminal_segmentation` → a "Display Image" reference, the image it annotates.

`intermediate` → a "Display Image" reference, the display image(s) it eventually feeds into.

`SharedJSFunctions.js` — one new function, `getDownstreamDisplayImages(uuid)`, similar to the existing `getImageFromAPI`/`getStudyFromApiByAccession` helpers already in this file.

There are three new components in `src/components/image/`:

`SpecimenTrackTableRow.astro` — a shared table row: a combined role label, image label, linked UUID, human-readable file size, download link. Used by both tables below.

`SpecimenTrackTable.astro` — the interactive version (sortable, filterable, paginated via DataTables magic...), used for "Upstream Images."

`DisplayImageTable.astro` — a plain static table, no DataTables at all, used for both "Display Image" cases.
